### PR TITLE
Don't pin cargo-deny, use v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: EmbarkStudios/cargo-deny-action@v1.0.1
+      - uses: EmbarkStudios/cargo-deny-action@v1
 
   publish-check:
     name: Publish Check


### PR DESCRIPTION
So we get automatic compatible updates to v1 action and don't have to manually update every time.