### PR TITLE
Support Alternate Registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2155,12 +2155,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "bitmaps"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +390,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,10 +417,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytesize"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
+
+[[package]]
 name = "cache-padded"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+
+[[package]]
+name = "cargo"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d435f32d32f191cdf788ef94403d7566dc5fcdadbcf7cd191cc0d2f9079d0a4"
+dependencies = [
+ "anyhow",
+ "atty",
+ "bytesize",
+ "cargo-platform",
+ "clap",
+ "core-foundation 0.9.0",
+ "crates-io",
+ "crossbeam-utils",
+ "crypto-hash",
+ "curl",
+ "curl-sys",
+ "env_logger",
+ "filetime",
+ "flate2",
+ "fwdansi",
+ "git2",
+ "git2-curl",
+ "glob",
+ "hex 0.4.2",
+ "home",
+ "humantime 2.0.1",
+ "ignore",
+ "im-rc",
+ "jobserver",
+ "lazy_static",
+ "lazycell",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "memchr",
+ "miow 0.3.5",
+ "num_cpus",
+ "opener",
+ "percent-encoding",
+ "rustc-workspace-hack",
+ "rustfix",
+ "same-file",
+ "semver 0.10.0",
+ "serde",
+ "serde_ignored",
+ "serde_json",
+ "shell-escape",
+ "strip-ansi-escapes",
+ "tar",
+ "tempfile",
+ "termcolor",
+ "toml",
+ "unicode-width",
+ "unicode-xid",
+ "url",
+ "walkdir",
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "cargo-fetcher"
@@ -417,13 +501,14 @@ dependencies = [
  "azure_sdk_storage_blob",
  "azure_sdk_storage_core",
  "bytes",
+ "cargo",
  "chrono",
  "difference",
  "digest",
  "flate2",
  "futures",
  "futures-util",
- "hex",
+ "hex 0.4.2",
  "http",
  "md5",
  "rayon",
@@ -449,6 +534,15 @@ dependencies = [
  "url",
  "walkdir",
  "zstd",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -528,6 +622,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "commoncrypto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
+dependencies = [
+ "commoncrypto-sys",
+]
+
+[[package]]
+name = "commoncrypto-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,7 +676,17 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.7.0",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b5ed8e7e76c45974e15e41bfa8d5b0483cd90191639e01d8f5f1e606299d3fb"
+dependencies = [
+ "core-foundation-sys 0.8.0",
  "libc",
 ]
 
@@ -575,10 +697,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a21fa21941700a3cd8fcb4091f361a6a712fac632f85d9f487cc892045d55c6"
+
+[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "crates-io"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f977948a46e9edf93eb3dc2d7a8dd4ce3105d36de63300befed37cdf051d4a"
+dependencies = [
+ "anyhow",
+ "curl",
+ "percent-encoding",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+]
 
 [[package]]
 name = "crc32fast"
@@ -634,6 +777,18 @@ dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-hash"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca"
+dependencies = [
+ "commoncrypto",
+ "hex 0.3.2",
+ "openssl",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -822,6 +977,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
  "libc",
+ "libz-sys",
  "miniz_oxide",
 ]
 
@@ -1008,10 +1164,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
+name = "git2"
+version = "0.13.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d97249f21e9542caeee9f8e1d150905cd875bf723f5ff771bdb4852eb83a24"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
+name = "git2-curl"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883539cb0ea94bab3f8371a98cd8e937bbe9ee7c044499184aa4c17deb643a50"
+dependencies = [
+ "curl",
+ "git2",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "globset"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "fnv",
+ "log",
+ "regex",
+]
 
 [[package]]
 name = "gloo-timers"
@@ -1072,6 +1268,12 @@ dependencies = [
 
 [[package]]
 name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+
+[[package]]
+name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
@@ -1084,6 +1286,15 @@ checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac",
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1192,6 +1403,38 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72"
+dependencies = [
+ "crossbeam-utils",
+ "globset",
+ "lazy_static",
+ "log",
+ "memchr",
+ "regex",
+ "same-file",
+ "thread_local",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "im-rc"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca8957e71f04a205cb162508f9326aea04676c8dfd0711220190d6b83664f3f"
+dependencies = [
+ "bitmaps",
+ "rand_core",
+ "rand_xoshiro",
+ "sized-chunks",
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1307,10 +1550,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.12.12+1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0100ae90655025134424939f1f60e27e879460d451dff6afedde4f8226cbebfc"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libnghttp2-sys"
+version = "0.1.4+1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca46220853ba1c512fc82826d0834d87b06bcd3c2a42241b7de72f3d2fe17056"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lock_api"
@@ -1605,10 +1904,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "opener"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13117407ca9d0caf3a0e74f97b490a7e64c0ae3aa90a8b7085544d0c37b6f3ae"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "lazy_static",
+ "libc",
+ "openssl-sys",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "parking"
@@ -1836,6 +2171,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,7 +2392,7 @@ dependencies = [
  "base64 0.12.3",
  "bytes",
  "futures",
- "hex",
+ "hex 0.4.2",
  "hmac",
  "http",
  "hyper",
@@ -2083,12 +2427,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
+name = "rustc-workspace-hack"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
+]
+
+[[package]]
+name = "rustfix"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2c50b74badcddeb8f7652fa8323ce440b95286f8e4b64ebfd871c609672704e"
+dependencies = [
+ "anyhow",
+ "log",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2183,8 +2545,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
  "bitflags",
- "core-foundation",
- "core-foundation-sys",
+ "core-foundation 0.7.0",
+ "core-foundation-sys 0.7.0",
  "libc",
  "security-framework-sys",
 ]
@@ -2195,7 +2557,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.7.0",
  "libc",
 ]
 
@@ -2206,6 +2568,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
+]
+
+[[package]]
+name = "semver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+dependencies = [
+ "semver-parser",
+ "serde",
 ]
 
 [[package]]
@@ -2244,6 +2616,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2c7d39d14f2f2ea82239de71594782f186fd03501ac81f0ce08e674819ff2f"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2311,6 +2692,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2323,6 +2710,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "sized-chunks"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
+dependencies = [
+ "bitmaps",
+ "typenum",
 ]
 
 [[package]]
@@ -2421,6 +2818,15 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
+
+[[package]]
+name = "strip-ansi-escapes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee"
+dependencies = [
+ "vte",
+]
 
 [[package]]
 name = "strsim"
@@ -2547,6 +2953,15 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all 0.5.3",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2910,6 +3325,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2921,6 +2921,7 @@ dependencies = [
  "idna",
  "matches",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,15 +347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "bitmaps"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "blake2b_simd"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,15 +381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31accafdb70df7871592c058eca3985b71104e15ac32f64706022c58867da931"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,76 +399,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
-name = "bytesize"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a18687293a1546b67c246452202bbbf143d239cb43494cc163da14979082da"
-
-[[package]]
 name = "cache-padded"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
-
-[[package]]
-name = "cargo"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d435f32d32f191cdf788ef94403d7566dc5fcdadbcf7cd191cc0d2f9079d0a4"
-dependencies = [
- "anyhow",
- "atty",
- "bytesize",
- "cargo-platform",
- "clap",
- "core-foundation 0.9.0",
- "crates-io",
- "crossbeam-utils",
- "crypto-hash",
- "curl",
- "curl-sys",
- "env_logger",
- "filetime",
- "flate2",
- "fwdansi",
- "git2",
- "git2-curl",
- "glob",
- "hex 0.4.2",
- "home",
- "humantime 2.0.1",
- "ignore",
- "im-rc",
- "jobserver",
- "lazy_static",
- "lazycell",
- "libc",
- "libgit2-sys",
- "log",
- "memchr",
- "miow 0.3.5",
- "num_cpus",
- "opener",
- "percent-encoding",
- "rustc-workspace-hack",
- "rustfix",
- "same-file",
- "semver 0.10.0",
- "serde",
- "serde_ignored",
- "serde_json",
- "shell-escape",
- "strip-ansi-escapes",
- "tar",
- "tempfile",
- "termcolor",
- "toml",
- "unicode-width",
- "unicode-xid",
- "url",
- "walkdir",
- "winapi 0.3.9",
-]
 
 [[package]]
 name = "cargo-fetcher"
@@ -501,14 +417,13 @@ dependencies = [
  "azure_sdk_storage_blob",
  "azure_sdk_storage_core",
  "bytes",
- "cargo",
  "chrono",
  "difference",
  "digest",
  "flate2",
  "futures",
  "futures-util",
- "hex 0.4.2",
+ "hex",
  "http",
  "md5",
  "rayon",
@@ -534,15 +449,6 @@ dependencies = [
  "url",
  "walkdir",
  "zstd",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0226944a63d1bf35a3b5f948dd7c59e263db83695c9e8bffc4037de02e30f1d7"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -622,24 +528,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "commoncrypto"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
-dependencies = [
- "commoncrypto-sys",
-]
-
-[[package]]
-name = "commoncrypto-sys"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,17 +564,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d24c7a13c43e870e37c1556b74555437870a04514f7685f5b354e090567171"
 dependencies = [
- "core-foundation-sys 0.7.0",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b5ed8e7e76c45974e15e41bfa8d5b0483cd90191639e01d8f5f1e606299d3fb"
-dependencies = [
- "core-foundation-sys 0.8.0",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -697,31 +575,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a21fa21941700a3cd8fcb4091f361a6a712fac632f85d9f487cc892045d55c6"
-
-[[package]]
 name = "cpuid-bool"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
-
-[[package]]
-name = "crates-io"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f977948a46e9edf93eb3dc2d7a8dd4ce3105d36de63300befed37cdf051d4a"
-dependencies = [
- "anyhow",
- "curl",
- "percent-encoding",
- "serde",
- "serde_derive",
- "serde_json",
- "url",
-]
 
 [[package]]
 name = "crc32fast"
@@ -777,18 +634,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
  "lazy_static",
-]
-
-[[package]]
-name = "crypto-hash"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca"
-dependencies = [
- "commoncrypto",
- "hex 0.3.2",
- "openssl",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -977,7 +822,6 @@ dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
  "libc",
- "libz-sys",
  "miniz_oxide",
 ]
 
@@ -1164,50 +1008,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
-name = "git2"
-version = "0.13.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d97249f21e9542caeee9f8e1d150905cd875bf723f5ff771bdb4852eb83a24"
-dependencies = [
- "bitflags",
- "libc",
- "libgit2-sys",
- "log",
- "openssl-probe",
- "openssl-sys",
- "url",
-]
-
-[[package]]
-name = "git2-curl"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "883539cb0ea94bab3f8371a98cd8e937bbe9ee7c044499184aa4c17deb643a50"
-dependencies = [
- "curl",
- "git2",
- "log",
- "url",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "globset"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ad1da430bd7281dde2576f44c84cc3f0f7b475e7202cd503042dff01a8c8120"
-dependencies = [
- "aho-corasick",
- "bstr",
- "fnv",
- "log",
- "regex",
-]
 
 [[package]]
 name = "gloo-timers"
@@ -1268,12 +1072,6 @@ dependencies = [
 
 [[package]]
 name = "hex"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
-
-[[package]]
-name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
@@ -1286,15 +1084,6 @@ checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac",
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
-dependencies = [
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1403,38 +1192,6 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dcbf2a4a289528dbef21686354904e1c694ac642610a9bff9e7df730d9ec72"
-dependencies = [
- "crossbeam-utils",
- "globset",
- "lazy_static",
- "log",
- "memchr",
- "regex",
- "same-file",
- "thread_local",
- "walkdir",
- "winapi-util",
-]
-
-[[package]]
-name = "im-rc"
-version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ca8957e71f04a205cb162508f9326aea04676c8dfd0711220190d6b83664f3f"
-dependencies = [
- "bitmaps",
- "rand_core",
- "rand_xoshiro",
- "sized-chunks",
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1550,66 +1307,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
-
-[[package]]
-name = "libgit2-sys"
-version = "0.12.12+1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0100ae90655025134424939f1f60e27e879460d451dff6afedde4f8226cbebfc"
-dependencies = [
- "cc",
- "libc",
- "libssh2-sys",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
-]
-
-[[package]]
-name = "libnghttp2-sys"
-version = "0.1.4+1.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03624ec6df166e79e139a2310ca213283d6b3c30810c54844f307086d4488df1"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "libssh2-sys"
-version = "0.2.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca46220853ba1c512fc82826d0834d87b06bcd3c2a42241b7de72f3d2fe17056"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "lock_api"
@@ -1904,46 +1605,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
-name = "opener"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13117407ca9d0caf3a0e74f97b490a7e64c0ae3aa90a8b7085544d0c37b6f3ae"
-dependencies = [
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "openssl"
-version = "0.10.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "lazy_static",
- "libc",
- "openssl-sys",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
-dependencies = [
- "autocfg",
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking"
@@ -2171,15 +1836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_xoshiro"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
 name = "rayon"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2392,7 +2048,7 @@ dependencies = [
  "base64 0.12.3",
  "bytes",
  "futures",
- "hex 0.4.2",
+ "hex",
  "hmac",
  "http",
  "hyper",
@@ -2427,30 +2083,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e3bad0ee36814ca07d7968269dd4b7ec89ec2da10c4bb613928d3077083c232"
 
 [[package]]
-name = "rustc-workspace-hack"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc71d2faa173b74b232dedc235e3ee1696581bb132fc116fa3626d6151a1a8fb"
-
-[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustfix"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c50b74badcddeb8f7652fa8323ce440b95286f8e4b64ebfd871c609672704e"
-dependencies = [
- "anyhow",
- "log",
- "serde",
- "serde_json",
+ "semver",
 ]
 
 [[package]]
@@ -2545,8 +2183,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64808902d7d99f78eaddd2b4e2509713babc3dc3c85ad6f4c447680f3c01e535"
 dependencies = [
  "bitflags",
- "core-foundation 0.7.0",
- "core-foundation-sys 0.7.0",
+ "core-foundation",
+ "core-foundation-sys",
  "libc",
  "security-framework-sys",
 ]
@@ -2557,7 +2195,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17bf11d99252f512695eb468de5516e5cf75455521e69dfe343f3b74e4748405"
 dependencies = [
- "core-foundation-sys 0.7.0",
+ "core-foundation-sys",
  "libc",
 ]
 
@@ -2568,16 +2206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
  "semver-parser",
-]
-
-[[package]]
-name = "semver"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
-dependencies = [
- "semver-parser",
- "serde",
 ]
 
 [[package]]
@@ -2616,15 +2244,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_ignored"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c2c7d39d14f2f2ea82239de71594782f186fd03501ac81f0ce08e674819ff2f"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2692,12 +2311,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-escape"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
-
-[[package]]
 name = "shlex"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2710,16 +2323,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce32ea0c6c56d5eacaeb814fbed9960547021d3edd010ded1425f180536b20ab"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "sized-chunks"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec31ceca5644fa6d444cc77548b88b67f46db6f7c71683b0f9336e671830d2f"
-dependencies = [
- "bitmaps",
- "typenum",
 ]
 
 [[package]]
@@ -2818,15 +2421,6 @@ name = "stdweb-internal-runtime"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
-
-[[package]]
-name = "strip-ansi-escapes"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d63676e2abafa709460982ddc02a3bb586b6d15a49b75c212e06edd3933acee"
-dependencies = [
- "vte",
-]
 
 [[package]]
 name = "strsim"
@@ -2953,15 +2547,6 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all 0.5.3",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]
@@ -3325,12 +2910,6 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
-
-[[package]]
-name = "utf8parse"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8772a4ccbb4e89959023bc5b7cb8623a795caa7092d99f3aa9501b9484d4557d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,10 +233,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d8dd27eee0644b886305eca21c48425403a8bb87ec57f52f516093504fa3a5"
 dependencies = [
  "RustyXML",
+ "anyhow",
  "base64 0.12.3",
  "bytes",
  "chrono",
- "failure",
  "futures",
  "http",
  "hyper",
@@ -769,28 +769,6 @@ name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
 
 [[package]]
 name = "fastrand"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,9 +50,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8dcb5b4bbaa28653b647d8c77bd4ed40183b48882e130c1f1ffb73de069fd7"
+checksum = "2c0df63cb2955042487fad3aefd2c6e3ae7389ac5dc1beb28921de0b69f779d4"
 
 [[package]]
 name = "app_dirs2"
@@ -118,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40a0b2bb8ae20fede194e779150fe283f65a4a08461b496de546ec366b174ad9"
+checksum = "9315f8f07556761c3e48fec2e6b276004acf426e6dc068b2c2251854d65ee0fd"
 dependencies = [
  "concurrent-queue",
  "fastrand",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.65"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95752358c8f7552394baf48cd82695b345628ad3f170d607de3ca03b8dacca15"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 dependencies = [
  "jobserver",
 ]
@@ -505,15 +505,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4344512281c643ae7638bbabc3af17a11307803ec8f0fcad9fae512a8bf36467"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -612,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0f606a85340376eef0d6d8fec399e6d4a544d648386c6645eb6d0653b27d9f"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
@@ -626,13 +617,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec91540d98355f690a86367e566ecad2e9e579f230230eb7c21398372be73ea5"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
  "cfg-if 1.0.0",
- "const_fn",
  "lazy_static",
 ]
 
@@ -1274,9 +1264,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca059e81d9486668f12d455a4ea6daa600bd408134cd17e3d3fb5a32d1f016f8"
+checksum = "cf3d7383929f7c9c7c2d0fa596f325832df98c3704f2c60553080f7127a58175"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1308,9 +1298,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.80"
+version = "0.2.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58d1b70b004888f764dfbf6a26a3b0342a1632d33968e4a179d8011c760614"
+checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
 name = "lock_api"
@@ -1372,9 +1362,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.5.6"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043175f069eda7b85febe4a74abbaeff828d9f8b448515d3151a14a3542811aa"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
 dependencies = [
  "autocfg",
 ]
@@ -1407,9 +1397,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce347092656428bc8eaf6201042cb551b8d67855af7374542a92a0fbfcac430"
+checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
 dependencies = [
  "cfg-if 0.1.10",
  "fuchsia-zircon",
@@ -1418,7 +1408,7 @@ dependencies = [
  "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.1",
+ "miow 0.2.2",
  "net2",
  "slab",
  "winapi 0.2.8",
@@ -1449,9 +1439,9 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
 dependencies = [
  "kernel32-sys",
  "net2",
@@ -1526,9 +1516,9 @@ checksum = "c44922cb3dbb1c70b5e5f443d63b64363a898564d739ba5198e3a9138442868d"
 
 [[package]]
 name = "net2"
-version = "0.2.35"
+version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ebc3ec692ed7c9a255596c67808dee269f64655d8baf7b4f0638e51ba1d6853"
+checksum = "d7cf75f38f16cb05ea017784dc6dbfd354f76c223dba37701734c4f5a9337d02"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
@@ -1629,12 +1619,11 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c361aa727dd08437f2f1447be8b59a33b0edd15e0fcee698f935613d9efbca9b"
+checksum = "d7c6d9b8427445284a09c55be860a15855ab580a417ccad9da88f5a06787ced0"
 dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -1965,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.17"
+version = "0.16.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5911690c9b773bab7e657471afc207f3827b249a657241327e3544d79bcabdd"
+checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
 dependencies = [
  "cc",
  "libc",
@@ -2155,6 +2144,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,9 +2205,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b88fa983de7720629c9387e9f517353ed404164b1e482c970a90c1a4aaf7dc1a"
+checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 dependencies = [
  "serde_derive",
 ]
@@ -2231,9 +2226,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.117"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd1ae72adb44aab48f325a02444a5fc079349a8d804c1fc922aed3f7454c74e"
+checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2242,9 +2237,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.59"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcac07dbffa1c65e7f816ab9eba78eb142c6d44410f4eeba1e26e4f5dfa56b95"
+checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
 dependencies = [
  "itoa",
  "ryu",
@@ -2327,9 +2322,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7acad6f34eb9e8a259d3283d1e8c1d34d7415943d4895f65cc73813c7396fc85"
+checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
 dependencies = [
  "serde",
 ]
@@ -2430,9 +2425,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126d630294ec449fae0b16f964e35bf3c74f940da9dca17ee9b905f7b3112eb8"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -2441,9 +2436,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e51c492f9e23a220534971ff5afc14037289de430e3c83f9daf6a1b6ae91e8"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -2460,24 +2455,12 @@ checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.51"
+version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
+checksum = "9a2af957a63d6bd42255c359c93d9bfdb97076bd3b820897ce55ffbfbf107f44"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 
@@ -2883,9 +2866,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8716a166f290ff49dabc18b44aa407cb7c6dbe1aa0971b44b8a24b0ca35aae"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
@@ -2986,11 +2969,11 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac64ead5ea5f05873d7c12b545865ca2b8d28adfc50a49b84770a3a97265d42"
+checksum = "3cd364751395ca0f68cafb17666eee36b63077fb5ecd972bbcd74c90c4bf736e"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "serde",
  "serde_json",
  "wasm-bindgen-macro",
@@ -2998,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22b422e2a757c35a73774860af8e112bff612ce6cb604224e8e47641a9e4f68"
+checksum = "1114f89ab1f4106e5b55e688b828c0ab0ea593a1ea7c094b141b14cbaaec2d62"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -3013,11 +2996,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7866cab0aa01de1edf8b5d7936938a7e397ee50ce24119aef3e1eaa3b6171da"
+checksum = "1fe9756085a84584ee9457a002b7cdfe0bfff169f45d2591d8be1345a6780e35"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -3025,9 +3008,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b13312a745c08c469f0b292dd2fcd6411dba5f7160f593da6ef69b64e407038"
+checksum = "7a6ac8995ead1f084a8dea1e65f194d0973800c7f571f6edd70adf06ecf77084"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3035,9 +3018,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f249f06ef7ee334cc3b8ff031bfc11ec99d00f34d86da7498396dc1e3b1498fe"
+checksum = "b5a48c72f299d80557c7c62e37e7225369ecc0c963964059509fbafe917c7549"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3048,15 +3031,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.68"
+version = "0.2.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d649a3145108d7d3fbcde896a468d1bd636791823c9921135218ad89be08307"
+checksum = "7e7811dd7f9398f14cc76efd356f98f03aa30419dea46aa810d71e819fc97158"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d1cdc8b98a557f24733d50a1199c4b0635e465eecba9c45b214544da197f64"
+checksum = "0355fa0c1f9b792a09b6dcb6a8be24d51e71e6d74972f9eb4a44c4c004d24a25"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -3068,9 +3051,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.18"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fb9c67be7439ee8ab1b7db502a49c05e51e2835b66796c705134d9b8e1a585"
+checksum = "27e07b46b98024c2ba2f9e83a10c2ef0515f057f2da299c1762a2017de80438b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3078,9 +3061,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.45"
+version = "0.3.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf6ef87ad7ae8008e15a355ce696bed26012b7caa21605188cfd8214ab51e2d"
+checksum = "222b1ef9334f92a21d3fb53dc3fd80f30836959a90f9274a626d7e06315ba3c3"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3088,9 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "webpki"
-version = "0.21.3"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab146130f5f790d45f82aeeb09e55a256573373ec64409fc19a6fb82fb1032ae"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
 dependencies = [
  "ring",
  "untrusted",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,10 +233,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57d8dd27eee0644b886305eca21c48425403a8bb87ec57f52f516093504fa3a5"
 dependencies = [
  "RustyXML",
- "anyhow",
  "base64 0.12.3",
  "bytes",
  "chrono",
+ "failure",
  "futures",
  "http",
  "hyper",
@@ -769,6 +769,28 @@ name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
 
 [[package]]
 name = "fastrand"
@@ -2450,6 +2472,18 @@ checksum = "3b4f34193997d92804d359ed09953e25d5138df6bcc055a71bf68ee89fdf9223"
 dependencies = [
  "proc-macro2",
  "quote",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
  "unicode-xid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "home",
  "http",
  "md5",
  "rayon",
@@ -1074,6 +1075,15 @@ checksum = "126888268dcc288495a26bf004b38c5fdbb31682f992c84ceb046a1f0fe38840"
 dependencies = [
  "crypto-mac",
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2456aef2e6b6a9784192ae780c0f15bc57df0e918585282325e8c8ac27737654"
+dependencies = [
+ "winapi 0.3.9",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,6 @@ tracing-subscriber = "0.2.1"
 url = "2.1.1"
 walkdir = "2.3.1"
 zstd = "0.5.1"
-cargo = "0.47.0"
 
 [dependencies.tokio]
 version = "0.2.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ app_dirs2 = "2.0"
 async-tar = "0.2"
 async-trait = "0.1"
 async-std = { version = "1.6.0", optional = true }
-azure_sdk_core = { version = "0.43", optional = true }
-azure_sdk_storage_blob = { version = "0.45", optional = true }
-azure_sdk_storage_core = { version = "0.44", optional = true }
+azure_sdk_core = { git = "https://github.com/m0ssc0de/AzureSDKForRust", version = "0.43", optional = true }
+azure_sdk_storage_blob = { git = "https://github.com/m0ssc0de/AzureSDKForRust", version = "0.45", optional = true }
+azure_sdk_storage_core = { git = "https://github.com/m0ssc0de/AzureSDKForRust", version = "0.44", optional = true }
 bytes = "0.5.4"
 chrono = "0.4.10"
 digest = { version = "0.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ tracing-subscriber = "0.2.1"
 url = "2.1.1"
 walkdir = "2.3.1"
 zstd = "0.5.1"
+cargo = "0.47.0"
 
 [dependencies.tokio]
 version = "0.2.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ toml = "0.5.6"
 tracing = "0.1.12"
 tracing-futures = "0.2.2"
 tracing-subscriber = "0.2.1"
-url = "2.1.1"
+url = { version = "2.1.1", features = ["serde"] }
 walkdir = "2.3.1"
 zstd = "0.5.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ flate2 = { version = "1.0", default-features = false, features = ["rust_backend"
 futures = { version = "0.3" }
 futures-util = { version = "0.3", features = ["async-await-macro"] }
 hex = { version = "0.4", optional = true }
+home = "0.5"
 http = "0.2"
 md5 = { version = "0.7", optional = true }
 rayon = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,43 +20,43 @@ anyhow = "1.0"
 app_dirs2 = "2.0"
 async-tar = "0.2"
 async-trait = "0.1"
-async-std = { version = "1.6.0", optional = true }
+async-std = { version = "1.6", optional = true }
 azure_sdk_core = { version = "0.43", optional = true }
 azure_sdk_storage_blob = { version = "0.45", optional = true }
 azure_sdk_storage_core = { version = "0.44", optional = true }
-bytes = "0.5.4"
-chrono = "0.4.10"
+bytes = "0.5"
+chrono = "0.4"
 digest = { version = "0.9", optional = true }
 flate2 = { version = "1.0", default-features = false, features = ["rust_backend"] }
-futures = { version = "0.3.4" }
-futures-util = { version = "0.3.4", features = ["async-await-macro"] }
-hex = { version = "0.4.2", optional = true }
-http = "0.2.0"
+futures = { version = "0.3" }
+futures-util = { version = "0.3", features = ["async-await-macro"] }
+hex = { version = "0.4", optional = true }
+http = "0.2"
 md5 = { version = "0.7", optional = true }
-rayon = "1.3.0"
+rayon = "1.3"
 remove_dir_all = "0.6"
-reqwest = { version = "0.10.1", default-features = false, features = ["rustls-tls"] }
-ring = "0.16.11"
+reqwest = { version = "0.10", default-features = false, features = ["rustls-tls"] }
+ring = "0.16"
 rusoto_core = { version = "0.45", default-features = false, features = ["rustls"], optional = true }
 rusoto_s3 = { version = "0.45", default-features = false, features = ["rustls"], optional = true }
-serde = { version = "1.0.104", features = ["derive"] }
-serde_json = { version = "1.0.1", optional = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", optional = true }
 sha2 = { version = "0.9", optional = true }
-structopt = "0.3.9"
-tame-gcs = { version = "0.8.0", optional = true }
-tame-oauth = { version = "0.4.2", features = ["gcp"], optional = true }
-tar = "0.4.26"
-tempfile = "3.1.0"
-toml = "0.5.6"
-tracing = "0.1.12"
-tracing-futures = "0.2.2"
-tracing-subscriber = "0.2.1"
-url = { version = "2.1.1", features = ["serde"] }
-walkdir = "2.3.1"
-zstd = "0.5.1"
+structopt = "0.3"
+tame-gcs = { version = "0.8", optional = true }
+tame-oauth = { version = "0.4", features = ["gcp"], optional = true }
+tar = "0.4"
+tempfile = "3.1"
+toml = "0.5"
+tracing = "0.1"
+tracing-futures = "0.2"
+tracing-subscriber = "0.2"
+url = { version = "2.1", features = ["serde"] }
+walkdir = "2.3"
+zstd = "0.5"
 
 [dependencies.tokio]
-version = "0.2.13"
+version = "0.2"
 features = ["rt-threaded", "rt-util", "blocking", "process", "macros"]
 
 [features]
@@ -68,10 +68,10 @@ fs_test = ["fs"]
 blob = ["azure_sdk_core", "azure_sdk_storage_core", "azure_sdk_storage_blob", "md5"]
 
 [dev-dependencies]
-difference = "2.0.0"
-tempfile = "3.1.0"
-twox-hash = "1.5.0"
-walkdir = "2.3.1"
+difference = "2.0"
+tempfile = "3.1"
+twox-hash = "1.5"
+walkdir = "2.3"
 
 [[test]]
 name = "sync_crates_io"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,9 @@ app_dirs2 = "2.0"
 async-tar = "0.2"
 async-trait = "0.1"
 async-std = { version = "1.6.0", optional = true }
-azure_sdk_core = { git = "https://github.com/m0ssc0de/AzureSDKForRust", version = "0.43", optional = true }
-azure_sdk_storage_blob = { git = "https://github.com/m0ssc0de/AzureSDKForRust", version = "0.45", optional = true }
-azure_sdk_storage_core = { git = "https://github.com/m0ssc0de/AzureSDKForRust", version = "0.44", optional = true }
+azure_sdk_core = { version = "0.43", optional = true }
+azure_sdk_storage_blob = { version = "0.45", optional = true }
+azure_sdk_storage_core = { version = "0.44", optional = true }
 bytes = "0.5.4"
 chrono = "0.4.10"
 digest = { version = "0.9", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -41,7 +41,7 @@ skip = [
     # mio-named-pipes brings in 2 versions of miow
     { name = "miow", version = "=0.2.1" },
 
-    # tempfile uses an older version
+    # tempfile uses an old version, but is only a dev-dep so it's fine
     { name = "remove_dir_all", version = "=0.5.3" },
 
     # chrono!? uses and old version of time

--- a/src/cmds/main.rs
+++ b/src/cmds/main.rs
@@ -1,3 +1,4 @@
+// Workaround for issue that was exacerbated by rust 1.46.0
 #![type_length_limit = r#"18961884"#]
 
 extern crate cargo_fetcher as cf;

--- a/src/cmds/main.rs
+++ b/src/cmds/main.rs
@@ -161,7 +161,7 @@ async fn real_main() -> Result<(), Error> {
     let p = cf::util::determine_cargo_root(None)?.join("config.toml");
     let registries = cf::read_cargo_config(p)?;
 
-    let krates = cf::read_lock_file(args.lock_file, registries)
+    let (krates, registries_url) = cf::read_lock_file(args.lock_file, registries)
         .context("failed to get crates from lock file")?;
 
     match args.cmd {

--- a/src/cmds/main.rs
+++ b/src/cmds/main.rs
@@ -158,8 +158,11 @@ async fn real_main() -> Result<(), Error> {
     let location = cf::util::parse_cloud_location(&cloud_location)?;
     let backend = init_backend(location, args.credentials).await?;
 
-    let krates =
-        cf::read_lock_file(args.lock_file).context("failed to get crates from lock file")?;
+    let p = cf::util::determine_cargo_root(None)?.join("config.toml");
+    let registries = cf::read_cargo_config(p)?;
+
+    let krates = cf::read_lock_file(args.lock_file, registries)
+        .context("failed to get crates from lock file")?;
 
     match args.cmd {
         Command::Mirror(margs) => {

--- a/src/cmds/main.rs
+++ b/src/cmds/main.rs
@@ -166,12 +166,13 @@ async fn real_main() -> Result<(), Error> {
 
     match args.cmd {
         Command::Mirror(margs) => {
-            let ctx = cf::Ctx::new(None, backend, krates).context("failed to create context")?;
+            let ctx = cf::Ctx::new(None, backend, krates, registries_url)
+                .context("failed to create context")?;
             mirror::cmd(ctx, args.include_index, margs).await
         }
         Command::Sync(sargs) => {
             let root_dir = cf::util::determine_cargo_root(sargs.cargo_root.as_ref())?;
-            let ctx = cf::Ctx::new(Some(root_dir), backend, krates)
+            let ctx = cf::Ctx::new(Some(root_dir), backend, krates, registries_url)
                 .context("failed to create context")?;
             sync::cmd(ctx, args.include_index, sargs).await
         }

--- a/src/cmds/main.rs
+++ b/src/cmds/main.rs
@@ -1,3 +1,4 @@
+#![type_length_limit = "8388608"]
 extern crate cargo_fetcher as cf;
 
 use anyhow::{anyhow, Context, Error};

--- a/src/cmds/main.rs
+++ b/src/cmds/main.rs
@@ -160,20 +160,20 @@ async fn real_main() -> Result<(), Error> {
     let backend = init_backend(location, args.credentials).await?;
 
     let p = cf::util::determine_cargo_root(None)?.join("config.toml");
-    let registries = cf::read_cargo_config(&p)?;
+    let registries_map = cf::read_cargo_config(&p)?;
 
-    let (krates, registries_url) = cf::read_lock_file(args.lock_file, registries)
+    let (krates, registries_vec) = cf::read_lock_file(args.lock_file, registries_map)
         .context("failed to get crates from lock file")?;
 
     match args.cmd {
         Command::Mirror(margs) => {
-            let ctx = cf::Ctx::new(None, backend, krates, registries_url)
+            let ctx = cf::Ctx::new(None, backend, krates, registries_vec)
                 .context("failed to create context")?;
             mirror::cmd(ctx, args.include_index, margs).await
         }
         Command::Sync(sargs) => {
             let root_dir = cf::util::determine_cargo_root(sargs.cargo_root.as_ref())?;
-            let ctx = cf::Ctx::new(Some(root_dir), backend, krates, registries_url)
+            let ctx = cf::Ctx::new(Some(root_dir), backend, krates, registries_vec)
                 .context("failed to create context")?;
             sync::cmd(ctx, args.include_index, sargs).await
         }

--- a/src/cmds/main.rs
+++ b/src/cmds/main.rs
@@ -160,7 +160,7 @@ async fn real_main() -> Result<(), Error> {
     let backend = init_backend(location, args.credentials).await?;
 
     let p = cf::util::determine_cargo_root(None)?.join("config.toml");
-    let registries = cf::read_cargo_config(p)?;
+    let registries = cf::read_cargo_config(&p)?;
 
     let (krates, registries_url) = cf::read_lock_file(args.lock_file, registries)
         .context("failed to get crates from lock file")?;

--- a/src/cmds/main.rs
+++ b/src/cmds/main.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "18958749"]
+#![type_length_limit = r#"18961884"#]
 
 extern crate cargo_fetcher as cf;
 

--- a/src/cmds/main.rs
+++ b/src/cmds/main.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "18958679"]
+#![type_length_limit = "18958689"]
 
 extern crate cargo_fetcher as cf;
 

--- a/src/cmds/main.rs
+++ b/src/cmds/main.rs
@@ -1,4 +1,4 @@
-#![type_length_limit = "18958689"]
+#![type_length_limit = "18958749"]
 
 extern crate cargo_fetcher as cf;
 

--- a/src/cmds/main.rs
+++ b/src/cmds/main.rs
@@ -1,4 +1,5 @@
-#![type_length_limit = "8388608"]
+#![type_length_limit = "18958679"]
+
 extern crate cargo_fetcher as cf;
 
 use anyhow::{anyhow, Context, Error};

--- a/src/cmds/mirror.rs
+++ b/src/cmds/mirror.rs
@@ -28,7 +28,7 @@ pub(crate) async fn cmd(ctx: Ctx, include_index: bool, args: Args) -> Result<(),
     let backend = ctx.backend.clone();
 
     let local = tokio::task::LocalSet::new();
-    let regs = ctx.registries_url.to_vec();
+    let regs = ctx.registries.to_vec();
     let index = local.run_until(async move {
         if !include_index {
             return;

--- a/src/cmds/mirror.rs
+++ b/src/cmds/mirror.rs
@@ -34,7 +34,7 @@ pub(crate) async fn cmd(ctx: Ctx, include_index: bool, args: Args) -> Result<(),
         }
 
         if let Err(e) = tokio::task::spawn_local(async move {
-            match mirror::registry_index(backend, args.max_stale)
+            match mirror::registry_index(backend, args.max_stale, None)
                 .instrument(tracing::info_span!("index"))
                 .await
             {

--- a/src/cmds/mirror.rs
+++ b/src/cmds/mirror.rs
@@ -28,20 +28,21 @@ pub(crate) async fn cmd(ctx: Ctx, include_index: bool, args: Args) -> Result<(),
     let backend = ctx.backend.clone();
 
     let local = tokio::task::LocalSet::new();
+    let regs = ctx.registries_url.to_vec();
     let index = local.run_until(async move {
         if !include_index {
             return;
         }
 
         if let Err(e) = tokio::task::spawn_local(async move {
-            match mirror::registry_index(backend, args.max_stale, None)
+            match mirror::registries_index(backend, args.max_stale, regs)
                 .instrument(tracing::info_span!("index"))
                 .await
             {
                 Ok(_) => {
-                    info!("successfully mirrored crates.io index");
+                    info!("successfully mirrored all registries index");
                 }
-                Err(e) => error!("failed to mirror crates.io index: {:#}", e),
+                Err(e) => error!("failed to mirror registries index: {:#}", e),
             }
         })
         .await

--- a/src/cmds/sync.rs
+++ b/src/cmds/sync.rs
@@ -23,7 +23,7 @@ pub(crate) async fn cmd(ctx: Ctx, include_index: bool, _args: Args) -> Result<()
         }
 
         info!("syncing crates.io index");
-        match sync::registry_index(root, backend).await {
+        match sync::registry_index(root, backend, None).await {
             Ok(_) => info!("successfully synced crates.io index"),
             Err(e) => error!(err = ?e, "failed to sync crates.io index"),
         }

--- a/src/cmds/sync.rs
+++ b/src/cmds/sync.rs
@@ -16,7 +16,7 @@ pub(crate) async fn cmd(ctx: Ctx, include_index: bool, _args: Args) -> Result<()
 
     let root = ctx.root_dir.clone();
     let backend = ctx.backend.clone();
-    let registries_url = ctx.registries_url.clone();
+    let registries = ctx.registries.clone();
 
     let index = tokio::task::spawn(async move {
         if !include_index {
@@ -24,7 +24,7 @@ pub(crate) async fn cmd(ctx: Ctx, include_index: bool, _args: Args) -> Result<()
         }
 
         info!("syncing registries index");
-        match sync::registries_index(root, backend, registries_url).await {
+        match sync::registries_index(root, backend, registries).await {
             Ok(_) => info!("successfully synced registries index"),
             Err(e) => error!(err = ?e, "failed to sync registries index"),
         }

--- a/src/cmds/sync.rs
+++ b/src/cmds/sync.rs
@@ -16,16 +16,17 @@ pub(crate) async fn cmd(ctx: Ctx, include_index: bool, _args: Args) -> Result<()
 
     let root = ctx.root_dir.clone();
     let backend = ctx.backend.clone();
+    let registries_url = ctx.registries_url.clone();
 
     let index = tokio::task::spawn(async move {
         if !include_index {
             return;
         }
 
-        info!("syncing crates.io index");
-        match sync::registry_index(root, backend, None).await {
-            Ok(_) => info!("successfully synced crates.io index"),
-            Err(e) => error!(err = ?e, "failed to sync crates.io index"),
+        info!("syncing registries index");
+        match sync::registries_index(root, backend, registries_url).await {
+            Ok(_) => info!("successfully synced registries index"),
+            Err(e) => error!(err = ?e, "failed to sync registries index"),
         }
     });
 

--- a/src/cmds/sync.rs
+++ b/src/cmds/sync.rs
@@ -1,14 +1,9 @@
 use anyhow::Error;
 use cf::{sync, Ctx};
-use std::path::PathBuf;
 use tracing::{error, info};
 
 #[derive(structopt::StructOpt)]
 pub struct Args {
-    /// The root path for cargo. This defaults to either
-    /// CARGO_HOME or HOME/.cargo.
-    #[structopt(short, long = "cargo-root", parse(from_os_str))]
-    pub cargo_root: Option<PathBuf>,
 }
 
 pub(crate) async fn cmd(ctx: Ctx, include_index: bool, _args: Args) -> Result<(), Error> {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -10,20 +10,6 @@ use tracing_futures::Instrument;
 pub async fn from_registry(client: &Client, krate: &Krate) -> Result<Bytes, Error> {
     async {
         match &krate.source {
-            Source::CratesIo(chksum) => {
-                let url = format!(
-                    "https://static.crates.io/crates/{}/{}-{}.crate",
-                    krate.name, krate.name, krate.version
-                );
-
-                let response = client.get(&url).send().await?.error_for_status()?;
-                let res = util::convert_response(response).await?;
-                let content = res.into_body();
-
-                util::validate_checksum(&content, &chksum)?;
-
-                Ok(content)
-            }
             Source::Git { url, rev, .. } => via_git(&url.clone().into(), rev).await,
             Source::Registry(registry, chksum) => {
                 let dl = registry

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -10,7 +10,7 @@ use tracing_futures::Instrument;
 pub async fn from_registry(client: &Client, krate: &Krate) -> Result<Bytes, Error> {
     async {
         match &krate.source {
-            Source::Git { url, rev, .. } => via_git(&url.clone().into(), rev).await,
+            Source::Git { url, rev, .. } => via_git(&url.clone(), rev).await,
             Source::Registry(registry, chksum) => {
                 let dl = registry
                     .dl

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,19 @@ pub struct Registry {
 }
 
 impl Registry {
+    pub fn new(
+        index: String,
+        token: Option<String>,
+        dl: Option<String>,
+        api: Option<String>,
+    ) -> Registry {
+        Registry {
+            index,
+            token,
+            dl,
+            api,
+        }
+    }
     // https://github.com/rust-lang/cargo/blob/master/src/cargo/sources/registry/mod.rs#L403-L407 blame f1e26ed3238f933fda177f06e913a70d8929dd6d
     pub fn short_name(&self) -> Result<String, Error> {
         let hash = util::short_hash(self);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ pub struct Ctx {
     pub client: reqwest::Client,
     pub backend: Storage,
     pub krates: Vec<Krate>,
-    pub registries_url: Vec<String>,
+    pub registries_url: Vec<Canonicalized>,
     pub root_dir: PathBuf,
 }
 
@@ -301,7 +301,7 @@ impl Ctx {
         root_dir: Option<PathBuf>,
         backend: Storage,
         krates: Vec<Krate>,
-        registries_url: Vec<String>,
+        registries_url: Vec<Canonicalized>,
     ) -> Result<Self, Error> {
         Ok(Self {
             client: reqwest::Client::builder().build()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -341,14 +341,16 @@ pub trait Backend: fmt::Debug {
     fn set_prefix(&mut self, prefix: &str);
 }
 
-pub fn read_cargo_config<P: AsRef<Path>>(
-    config_path: P,
-) -> Result<Option<HashMap<String, Registry>>, Error> {
+pub fn read_cargo_config(config_path: &Path) -> Result<Option<HashMap<String, Registry>>, Error> {
     let config: CargoConfig = {
         let config_contents = match std::fs::read_to_string(config_path) {
             Ok(s) => s,
             Err(e) => {
-                info!("failed to read cargo config: {}", e);
+                info!(
+                    "failed to read cargo config({}): {}",
+                    config_path.display(),
+                    e
+                );
                 return Ok(None);
             }
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,7 @@ pub struct Ctx {
     pub client: reqwest::Client,
     pub backend: Storage,
     pub krates: Vec<Krate>,
+    pub registries_url: Vec<String>,
     pub root_dir: PathBuf,
 }
 
@@ -299,11 +300,13 @@ impl Ctx {
         root_dir: Option<PathBuf>,
         backend: Storage,
         krates: Vec<Krate>,
+        registries_url: Vec<String>,
     ) -> Result<Self, Error> {
         Ok(Self {
             client: reqwest::Client::builder().build()?,
             backend,
             krates,
+            registries_url,
             root_dir: root_dir.unwrap_or_else(|| PathBuf::from(".")),
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use tracing::{error, info, trace};
 pub use url::Url;
 
 pub mod backends;
@@ -344,7 +345,13 @@ pub fn read_cargo_config<P: AsRef<Path>>(
     config_path: P,
 ) -> Result<Option<HashMap<String, Registry>>, Error> {
     let config: CargoConfig = {
-        let config_contents = std::fs::read_to_string(config_path)?;
+        let config_contents = match std::fs::read_to_string(config_path) {
+            Ok(s) => s,
+            Err(e) => {
+                info!("failed to read cargo config: {}", e);
+                return Ok(None);
+            }
+        };
         toml::from_str(&config_contents)?
     };
     match config.registries {
@@ -364,7 +371,6 @@ pub fn read_lock_file<P: AsRef<Path>>(
     registries: Option<HashMap<String, Registry>>,
 ) -> Result<(Vec<Krate>, Vec<Canonicalized>), Error> {
     use std::fmt::Write;
-    use tracing::{error, trace};
 
     let mut locks: LockContents = {
         let toml_contents = std::fs::read_to_string(lock_path)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,11 @@ impl Source {
     }
 
     pub(crate) fn is_git(&self) -> bool {
-        !matches!(self, Source::CratesIo(_))
+        match self {
+            Source::CratesIo(_) => false,
+            Source::Registry(_, _) => false,
+            _ => true,
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,7 +354,7 @@ pub fn read_cargo_config<P: AsRef<Path>>(
 pub fn read_lock_file<P: AsRef<Path>>(
     lock_path: P,
     registries: Option<HashMap<String, Registry>>,
-) -> Result<Vec<Krate>, Error> {
+) -> Result<(Vec<Krate>, Vec<String>), Error> {
     use std::fmt::Write;
     use tracing::{error, trace};
 
@@ -366,6 +366,7 @@ pub fn read_lock_file<P: AsRef<Path>>(
     let mut lookup = String::with_capacity(128);
     let mut krates = Vec::with_capacity(locks.package.len());
 
+    let mut registries_url_map = HashMap::new();
     for p in locks.package {
         let source = match p.source.as_ref() {
             Some(s) => s,
@@ -376,6 +377,7 @@ pub fn read_lock_file<P: AsRef<Path>>(
         };
 
         if source == "registry+https://github.com/rust-lang/crates.io-index" {
+            registries_url_map.insert(source.clone(), 1);
             match p.checksum {
                 Some(chksum) => krates.push(Krate {
                     name: p.name,
@@ -402,6 +404,7 @@ pub fn read_lock_file<P: AsRef<Path>>(
                 }
             }
         } else if source.starts_with("registry+") {
+            registries_url_map.insert(source.clone(), 1);
             let regs = registries.clone().context(format!(
                 "failed to find the registry {} in cargo config file",
                 source
@@ -461,5 +464,6 @@ pub fn read_lock_file<P: AsRef<Path>>(
         }
     }
 
-    Ok(krates)
+    let registry_urls = registries_url_map.into_iter().map(|(u, _)| u).collect();
+    Ok((krates, registry_urls))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,7 +320,7 @@ pub struct Ctx {
     pub client: reqwest::Client,
     pub backend: Storage,
     pub krates: Vec<Krate>,
-    pub registries_url: Vec<Registry>,
+    pub registries: Vec<Registry>,
     pub root_dir: PathBuf,
 }
 
@@ -329,13 +329,13 @@ impl Ctx {
         root_dir: Option<PathBuf>,
         backend: Storage,
         krates: Vec<Krate>,
-        registries_url: Vec<Registry>,
+        registries: Vec<Registry>,
     ) -> Result<Self, Error> {
         Ok(Self {
             client: reqwest::Client::builder().build()?,
             backend,
             krates,
-            registries_url,
+            registries,
             root_dir: root_dir.unwrap_or_else(|| PathBuf::from(".")),
         })
     }

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -1,26 +1,18 @@
+use crate::util::Canonicalized;
 use crate::{fetch, util, Ctx, Krate, Source};
 use anyhow::Context;
 use anyhow::Error;
 use std::path::Path;
-use std::{convert::TryFrom, time::Duration};
+use std::time::Duration;
 use tracing::{debug, error, info};
 use tracing_futures::Instrument;
-
-pub const CRATES_IO_URL: &str = "https://github.com/rust-lang/crates.io-index";
 
 pub async fn registry_index(
     backend: crate::Storage,
     max_stale: Duration,
-    registry_url: Option<util::Canonicalized>,
+    registry_url: Option<Canonicalized>,
 ) -> Result<usize, Error> {
-    let canonicalized = match registry_url {
-        Some(u) => u,
-        None => {
-            let u = url::Url::parse(CRATES_IO_URL)?;
-            util::Canonicalized::try_from(&u)?
-        }
-    };
-    let ident = canonicalized.ident();
+    let (canonicalized, ident) = util::decode_registry_url(registry_url)?;
 
     let url: url::Url = canonicalized.into();
     let url4index = url.clone();

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -1,8 +1,6 @@
 use crate::{fetch, Ctx, Krate, Registry, Source};
-use anyhow::Context;
 use anyhow::Error;
 use futures::StreamExt;
-use std::path::Path;
 use std::time::Duration;
 use tracing::{debug, error, info};
 use tracing_futures::Instrument;
@@ -47,19 +45,10 @@ pub async fn registry_index(
     let url = url::Url::parse(&registry.index)?;
     let ident = registry.short_name()?;
 
-    let path = Path::new(url.path());
-    let name = if path.ends_with(".git") {
-        path.file_stem().context("failed to get registry name")?
-    } else {
-        path.file_name().context("failed to get registry name")?
-    };
     // Create a fake krate for the index, we don't have to worry about clashing
     // since we use a `.` which is not an allowed character in crate names
     let krate = Krate {
-        name: String::from(
-            name.to_str()
-                .context("failed conversion from OsStr to String")?,
-        ),
+        name: ident.clone(),
         version: "1.0.0".to_owned(),
         source: Source::Git {
             url: url.clone().into(),

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -114,8 +114,7 @@ pub async fn crates(ctx: &Ctx) -> Result<usize, Error> {
             let client = &client;
             let backend = backend.clone();
             async move {
-                let res: Result<usize, String> = match fetch::from_crates_io(&client, &krate).await
-                {
+                let res: Result<usize, String> = match fetch::from_registry(&client, &krate).await {
                     Err(e) => Err(format!("failed to retrieve {}: {}", krate, e)),
                     Ok(buffer) => {
                         debug!(size = buffer.len(), "fetched");

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -1,12 +1,15 @@
 use crate::{fetch, util, Ctx, Krate, Source};
 use anyhow::Error;
+use cargo::core::SourceId;
+use cargo::util::config::Config;
 use std::{convert::TryFrom, time::Duration};
 use tracing::{debug, error, info};
 use tracing_futures::Instrument;
 
 pub async fn registry_index(backend: crate::Storage, max_stale: Duration) -> Result<usize, Error> {
-    let url = url::Url::parse("git+https://github.com/rust-lang/crates.io-index.git")?;
-    let canonicalized = util::Canonicalized::try_from(&url)?;
+    let cfg = Config::default()?;
+    let crates_io_url = SourceId::crates_io(&cfg)?.url().clone();
+    let canonicalized = util::Canonicalized::try_from(&crates_io_url)?;
     let ident = canonicalized.ident();
 
     // Create a fake krate for the index, we don't have to worry about clashing

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -22,7 +22,7 @@ pub async fn registries_index(
                     .await;
                 res
             }
-            .instrument(tracing::debug_span!("mirror registry", %index))
+            .instrument(tracing::debug_span!("mirror registries", %index))
         })
         .buffer_unordered(32);
     let total_bytes = bytes

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -77,8 +77,8 @@ pub async fn registry_index(
 
             if now - last_updated < max_dur {
                 info!(
-                    "crates.io-index was last updated {}, skipping update as it less than {:?} old",
-                    last_updated, max_stale
+                    "the registry ({}) was last updated {}, skipping update as it less than {:?} old",
+                    url, last_updated, max_stale
                 );
                 return Ok(0);
             }

--- a/src/mirror.rs
+++ b/src/mirror.rs
@@ -51,7 +51,7 @@ pub async fn registry_index(
         name: ident.clone(),
         version: "1.0.0".to_owned(),
         source: Source::Git {
-            url: url.clone().into(),
+            url: url.clone(),
             ident,
             rev: String::new(),
         },

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -365,18 +365,6 @@ pub async fn crates(ctx: &crate::Ctx) -> Result<Summary, Error> {
                                     return Err(e);
                                 }
                             }
-                            Source::CratesIo(ref chksum) => {
-                                let cache_dir = root_dir.join(CACHE_DIR);
-                                let src_dir = root_dir.join(SRC_DIR);
-                                if let Err(e) =
-                                    sync_package(&cache_dir, &src_dir, krate, krate_data, chksum)
-                                        .instrument(tracing::debug_span!("package"))
-                                        .await
-                                {
-                                    error!(err = ?e, "failed to splat package");
-                                    return Err(e);
-                                }
-                            }
                             Source::Git { rev, .. } => {
                                 if let Err(e) =
                                     sync_git(git_db_dir, git_co_dir, krate, krate_data, rev)

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -314,7 +314,8 @@ pub async fn crates(ctx: &crate::Ctx) -> Result<Summary, Error> {
     let git_db_dir = root_dir.join(GIT_DB_DIR);
     let git_co_dir = root_dir.join(GIT_CO_DIR);
 
-    for url in ctx.registries_url.iter() {
+    for url in ctx.registries.iter() {
+        // let (_, ident) = util::decode_registry_url(Some(url.clone()))?;
         let ident = url.short_name()?;
         let cache_dir = root_dir.join(CACHE_PATH).join(ident.clone());
         let src_dir = root_dir.join(SRC_PATH).join(ident.clone());

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -4,6 +4,8 @@ use std::{convert::TryFrom, io::Write, path::PathBuf};
 use tracing::{debug, error, info, warn};
 use tracing_futures::Instrument;
 
+pub const CRATES_IO_URL: &str = "https://github.com/rust-lang/crates.io-index";
+pub const INDEX_PATH: &str = "registry/index";
 pub const INDEX_DIR: &str = "registry/index/github.com-1ecc6299db9ec823";
 pub const CACHE_DIR: &str = "registry/cache/github.com-1ecc6299db9ec823";
 pub const SRC_DIR: &str = "registry/src/github.com-1ecc6299db9ec823";
@@ -11,7 +13,9 @@ pub const GIT_DB_DIR: &str = "git/db";
 pub const GIT_CO_DIR: &str = "git/checkouts";
 
 pub async fn registry_index(root_dir: PathBuf, backend: crate::Storage) -> Result<(), Error> {
-    let index_path = root_dir.join(INDEX_DIR);
+    let u = url::Url::parse(CRATES_IO_URL)?;
+    let ident = util::Canonicalized::try_from(&u)?.ident();
+    let index_path = root_dir.join(INDEX_PATH).join(ident);
     std::fs::create_dir_all(&index_path).context("failed to create index dir")?;
 
     // Just skip the index if the git directory already exists,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -315,7 +315,6 @@ pub async fn crates(ctx: &crate::Ctx) -> Result<Summary, Error> {
     let git_co_dir = root_dir.join(GIT_CO_DIR);
 
     for url in ctx.registries.iter() {
-        // let (_, ident) = util::decode_registry_url(Some(url.clone()))?;
         let ident = url.short_name()?;
         let cache_dir = root_dir.join(CACHE_PATH).join(ident.clone());
         let src_dir = root_dir.join(SRC_PATH).join(ident.clone());

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -83,17 +83,8 @@ pub async fn registry_index(
     }
 
     let url = url::Url::parse(&registry.index)?;
-    let path = Path::new(url.path());
-    let name = if path.ends_with(".git") {
-        path.file_stem().context("failed to get registry name")?
-    } else {
-        path.file_name().context("failed to get registry name")?
-    };
     let krate = Krate {
-        name: String::from(
-            name.to_str()
-                .context("failed conversion from OsStr to String")?,
-        ),
+        name: ident.clone(),
         version: "1.0.0".to_owned(),
         source: Source::Git {
             url: url.into(),

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -87,7 +87,7 @@ pub async fn registry_index(
         name: ident.clone(),
         version: "1.0.0".to_owned(),
         source: Source::Git {
-            url: url.into(),
+            url,
             ident,
             rev: String::new(),
         },

--- a/src/util.rs
+++ b/src/util.rs
@@ -665,17 +665,3 @@ mod test {
         assert_eq!(loc.prefix, "some_prefix/");
     }
 }
-
-pub fn decode_registry_url(
-    registry_url: Option<Canonicalized>,
-) -> Result<(Canonicalized, String), Error> {
-    let canonicalized = match registry_url {
-        Some(u) => u,
-        None => {
-            let u = url::Url::parse(CRATES_IO_URL)?;
-            Canonicalized::try_from(&u)?
-        }
-    };
-    let ident = canonicalized.ident();
-    Ok((canonicalized, ident))
-}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,4 @@
 use anyhow::{anyhow, bail, Context, Error};
-use cargo::core::SourceId;
-use cargo::sources::registry::RegistrySource;
-use cargo::util::config::Config;
-use std::collections::HashSet;
 use std::convert::TryFrom;
 #[allow(deprecated)]
 use std::{
@@ -682,16 +678,4 @@ pub fn decode_registry_url(
     };
     let ident = canonicalized.ident();
     Ok((canonicalized, ident))
-}
-
-pub fn dl_from(registry_url: &str) -> Result<String, Error> {
-    let cfg = Config::default()?;
-    cfg.acquire_package_cache_lock()?;
-    let source_id = SourceId::from_url(&url::Url::parse(registry_url)?.to_string())?;
-    let mut r = RegistrySource::remote(source_id, &HashSet::new(), &cfg);
-    let a = r
-        .config()?
-        .context("failed to get alt registry with None")?
-        .dl;
-    Ok(a)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, bail, Context, Error};
+use std::convert::TryFrom;
 #[allow(deprecated)]
 use std::{
     hash::{Hash, Hasher, SipHasher},
@@ -6,6 +7,8 @@ use std::{
 };
 use tracing::debug;
 use url::Url;
+
+pub const CRATES_IO_URL: &str = "https://github.com/rust-lang/crates.io-index";
 
 fn to_hex(num: u64) -> String {
     const CHARS: &[u8] = b"0123456789abcdef";
@@ -653,4 +656,18 @@ mod test {
         assert_eq!(loc.host, "amazonaws.com");
         assert_eq!(loc.prefix, "some_prefix/");
     }
+}
+
+pub fn decode_registry_url(
+    registry_url: Option<Canonicalized>,
+) -> Result<(Canonicalized, String), Error> {
+    let canonicalized = match registry_url {
+        Some(u) => u,
+        None => {
+            let u = url::Url::parse(CRATES_IO_URL)?;
+            Canonicalized::try_from(&u)?
+        }
+    };
+    let ident = canonicalized.ident();
+    Ok((canonicalized, ident))
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,8 @@
 use anyhow::{anyhow, bail, Context, Error};
+use cargo::core::SourceId;
+use cargo::sources::registry::RegistrySource;
+use cargo::util::config::Config;
+use std::collections::HashSet;
 use std::convert::TryFrom;
 #[allow(deprecated)]
 use std::{
@@ -670,4 +674,16 @@ pub fn decode_registry_url(
     };
     let ident = canonicalized.ident();
     Ok((canonicalized, ident))
+}
+
+pub fn dl_from(registry_url: &str) -> Result<String, Error> {
+    let cfg = Config::default()?;
+    cfg.acquire_package_cache_lock()?;
+    let source_id = SourceId::from_url(&url::Url::parse(registry_url)?.to_string())?;
+    let mut r = RegistrySource::remote(source_id, &HashSet::new(), &cfg);
+    let a = r
+        .config()?
+        .context("failed to get alt registry with None")?
+        .dl;
+    Ok(a)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::convert::TryFrom;
 #[allow(deprecated)]
 use std::{
+    fmt,
     hash::{Hash, Hasher, SipHasher},
     path::{Path, PathBuf},
 };
@@ -53,6 +54,7 @@ fn short_hash<H: Hash>(hashable: &H) -> String {
     to_hex(hash_u64(hashable))
 }
 
+#[derive(Clone)]
 pub struct Canonicalized(Url);
 
 impl Canonicalized {
@@ -67,6 +69,12 @@ impl Canonicalized {
         let ident = if ident == "" { "_empty" } else { ident };
 
         format!("{}-{}", ident, short_hash(&self.0))
+    }
+}
+
+impl fmt::Display for Canonicalized {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_ref())
     }
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,4 @@
 use anyhow::{anyhow, bail, Context, Error};
-use std::convert::TryFrom;
 #[allow(deprecated)]
 use std::{
     fmt,

--- a/src/util.rs
+++ b/src/util.rs
@@ -9,6 +9,7 @@ use tracing::debug;
 use url::Url;
 
 pub const CRATES_IO_URL: &str = "https://github.com/rust-lang/crates.io-index";
+pub const CRATES_IO_DL: &str = "https://crates.io/api/v1/crates";
 
 fn to_hex(num: u64) -> String {
     const CHARS: &[u8] = b"0123456789abcdef";

--- a/src/util.rs
+++ b/src/util.rs
@@ -46,7 +46,7 @@ fn hash_u64<H: Hash>(hashable: H) -> u64 {
     hasher.finish()
 }
 
-fn short_hash<H: Hash>(hashable: &H) -> String {
+pub fn short_hash<H: Hash>(hashable: &H) -> String {
     to_hex(hash_u64(hashable))
 }
 

--- a/tests/diff_cargo.rs
+++ b/tests/diff_cargo.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::{cmp::Ordering, fs::File, path::Path};
 use walkdir::{DirEntry, WalkDir};
 
@@ -141,7 +140,7 @@ async fn diff_cargo() {
     {
         fs_ctx.root_dir = fetcher_root.path().to_owned();
 
-        let (the_krates, _) = cf::read_lock_file("tests/full/Cargo.lock", HashMap::new()).unwrap();
+        let (the_krates, _) = cf::read_lock_file("tests/full/Cargo.lock", Vec::new()).unwrap();
         fs_ctx.krates = the_krates;
         let the_registry = cf::Registry::new(
             "https://github.com/rust-lang/crates.io-index".to_owned(),

--- a/tests/diff_cargo.rs
+++ b/tests/diff_cargo.rs
@@ -127,7 +127,13 @@ use tutil as util;
 #[ignore]
 async fn diff_cargo() {
     let fs_root = tempfile::TempDir::new().expect("failed to create tempdir");
-    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned()).await;
+    let registries = vec![cf::Registry::new(
+        "https://github.com/rust-lang/crates.io-index".to_owned(),
+        None,
+        None,
+        None,
+    )];
+    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned(), registries).await;
 
     let fetcher_root = tempfile::TempDir::new().expect("failed to create tempdir");
 

--- a/tests/lock.rs
+++ b/tests/lock.rs
@@ -1,22 +1,21 @@
 use cargo_fetcher::read_lock_file;
-use std::collections::HashMap;
 
 #[test]
 fn parses_v1() {
-    let (krates, _) = read_lock_file("tests/v1.lock", HashMap::new()).unwrap();
+    let (krates, _) = read_lock_file("tests/v1.lock", Vec::new()).unwrap();
     assert_eq!(krates.len(), 258);
 }
 
 #[test]
 fn parses_v2() {
-    let (krates, _) = read_lock_file("tests/v2.lock", HashMap::new()).unwrap();
+    let (krates, _) = read_lock_file("tests/v2.lock", Vec::new()).unwrap();
     assert_eq!(krates.len(), 258);
 }
 
 #[test]
 fn matches() {
-    let (krates1, _) = read_lock_file("tests/v1.lock", HashMap::new()).unwrap();
-    let (krates2, _) = read_lock_file("tests/v2.lock", HashMap::new()).unwrap();
+    let (krates1, _) = read_lock_file("tests/v1.lock", Vec::new()).unwrap();
+    let (krates2, _) = read_lock_file("tests/v2.lock", Vec::new()).unwrap();
 
     assert_eq!(krates1, krates2);
 }

--- a/tests/lock.rs
+++ b/tests/lock.rs
@@ -1,21 +1,22 @@
 use cargo_fetcher::read_lock_file;
+use std::collections::HashMap;
 
 #[test]
 fn parses_v1() {
-    let krates = read_lock_file("tests/v1.lock", None).unwrap();
+    let (krates, _) = read_lock_file("tests/v1.lock", HashMap::new()).unwrap();
     assert_eq!(krates.len(), 258);
 }
 
 #[test]
 fn parses_v2() {
-    let krates = read_lock_file("tests/v2.lock", None).unwrap();
+    let (krates, _) = read_lock_file("tests/v2.lock", HashMap::new()).unwrap();
     assert_eq!(krates.len(), 258);
 }
 
 #[test]
 fn matches() {
-    let krates1 = read_lock_file("tests/v1.lock", None).unwrap();
-    let krates2 = read_lock_file("tests/v2.lock", None).unwrap();
+    let (krates1, _) = read_lock_file("tests/v1.lock", HashMap::new()).unwrap();
+    let (krates2, _) = read_lock_file("tests/v2.lock", HashMap::new()).unwrap();
 
     assert_eq!(krates1, krates2);
 }

--- a/tests/lock.rs
+++ b/tests/lock.rs
@@ -2,20 +2,20 @@ use cargo_fetcher::read_lock_file;
 
 #[test]
 fn parses_v1() {
-    let krates = read_lock_file("tests/v1.lock").unwrap();
+    let krates = read_lock_file("tests/v1.lock", None).unwrap();
     assert_eq!(krates.len(), 258);
 }
 
 #[test]
 fn parses_v2() {
-    let krates = read_lock_file("tests/v2.lock").unwrap();
+    let krates = read_lock_file("tests/v2.lock", None).unwrap();
     assert_eq!(krates.len(), 258);
 }
 
 #[test]
 fn matches() {
-    let krates1 = read_lock_file("tests/v1.lock").unwrap();
-    let krates2 = read_lock_file("tests/v2.lock").unwrap();
+    let krates1 = read_lock_file("tests/v1.lock", None).unwrap();
+    let krates2 = read_lock_file("tests/v2.lock", None).unwrap();
 
     assert_eq!(krates1, krates2);
 }

--- a/tests/sync_crates_io.rs
+++ b/tests/sync_crates_io.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use cargo_fetcher as cf;
-use cf::{Krate, Source};
+use cf::{Krate, Registry, Source};
 
 mod tutil;
 use tutil as util;
@@ -8,7 +8,13 @@ use tutil as util;
 #[tokio::test(threaded_scheduler)]
 async fn all_missing() {
     let fs_root = tempfile::TempDir::new().expect("failed to create tempdir");
-    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned()).await;
+    let registries = vec![Registry::new(
+        "https://github.com/rust-lang/crates.io-index".to_owned(),
+        None,
+        None,
+        None,
+    )];
+    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned(), registries).await;
 
     let missing_root = tempfile::TempDir::new().expect("failed to crate tempdir");
     fs_ctx.root_dir = missing_root.path().to_owned();
@@ -86,7 +92,13 @@ async fn all_missing() {
 #[tokio::test(threaded_scheduler)]
 async fn some_missing() {
     let fs_root = tempfile::TempDir::new().expect("failed to create tempdir");
-    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned()).await;
+    let registries = vec![Registry::new(
+        "https://github.com/rust-lang/crates.io-index".to_owned(),
+        None,
+        None,
+        None,
+    )];
+    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned(), registries).await;
 
     let missing_root = tempfile::TempDir::new().expect("failed to crate tempdir");
     fs_ctx.root_dir = missing_root.path().to_owned();
@@ -200,7 +212,13 @@ async fn some_missing() {
 #[tokio::test(threaded_scheduler)]
 async fn none_missing() {
     let fs_root = tempfile::TempDir::new().expect("failed to create tempdir");
-    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned()).await;
+    let registries = vec![Registry::new(
+        "https://github.com/rust-lang/crates.io-index".to_owned(),
+        None,
+        None,
+        None,
+    )];
+    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned(), registries).await;
 
     let missing_root = tempfile::TempDir::new().expect("failed to crate tempdir");
     fs_ctx.root_dir = missing_root.path().to_owned();

--- a/tests/sync_crates_io.rs
+++ b/tests/sync_crates_io.rs
@@ -8,12 +8,13 @@ use tutil as util;
 #[tokio::test(threaded_scheduler)]
 async fn all_missing() {
     let fs_root = tempfile::TempDir::new().expect("failed to create tempdir");
-    let registries = vec![Registry::new(
+    let registry = Registry::new(
         "https://github.com/rust-lang/crates.io-index".to_owned(),
         None,
+        Some("https://crates.io/api/v1/crates".to_owned()),
         None,
-        None,
-    )];
+    );
+    let registries = vec![registry.clone()];
     let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned(), registries).await;
 
     let missing_root = tempfile::TempDir::new().expect("failed to crate tempdir");
@@ -23,21 +24,24 @@ async fn all_missing() {
         Krate {
             name: "ansi_term".to_owned(),
             version: "0.11.0".to_owned(),
-            source: Source::CratesIo(
+            source: Source::Registry(
+                registry.clone(),
                 "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b".to_owned(),
             ),
         },
         Krate {
             name: "base64".to_owned(),
             version: "0.10.1".to_owned(),
-            source: Source::CratesIo(
+            source: Source::Registry(
+                registry.clone(),
                 "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e".to_owned(),
             ),
         },
         Krate {
             name: "uuid".to_owned(),
             version: "0.7.4".to_owned(),
-            source: Source::CratesIo(
+            source: Source::Registry(
+                registry.clone(),
                 "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a".to_owned(),
             ),
         },
@@ -71,8 +75,10 @@ async fn all_missing() {
             };
 
             match krate.source {
-                Source::CratesIo(ref chksum) => cf::util::validate_checksum(&bytes, chksum)
+                Source::Registry(_, ref chksum) => cf::util::validate_checksum(&bytes, chksum)
                     .expect("failed to validate checksum"),
+                // Source::CratesIo(ref chksum) => cf::util::validate_checksum(&bytes, chksum)
+                //     .expect("failed to validate checksum"),
                 _ => unreachable!(),
             }
         }
@@ -92,12 +98,13 @@ async fn all_missing() {
 #[tokio::test(threaded_scheduler)]
 async fn some_missing() {
     let fs_root = tempfile::TempDir::new().expect("failed to create tempdir");
-    let registries = vec![Registry::new(
+    let registry = Registry::new(
         "https://github.com/rust-lang/crates.io-index".to_owned(),
         None,
+        Some("https://crates.io/api/v1/crates".to_owned()),
         None,
-        None,
-    )];
+    );
+    let registries = vec![registry.clone()];
     let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned(), registries).await;
 
     let missing_root = tempfile::TempDir::new().expect("failed to crate tempdir");
@@ -107,21 +114,24 @@ async fn some_missing() {
         Krate {
             name: "ansi_term".to_owned(),
             version: "0.11.0".to_owned(),
-            source: Source::CratesIo(
+            source: Source::Registry(
+                registry.clone(),
                 "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b".to_owned(),
             ),
         },
         Krate {
             name: "base64".to_owned(),
             version: "0.10.1".to_owned(),
-            source: Source::CratesIo(
+            source: Source::Registry(
+                registry.clone(),
                 "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e".to_owned(),
             ),
         },
         Krate {
             name: "uuid".to_owned(),
             version: "0.7.4".to_owned(),
-            source: Source::CratesIo(
+            source: Source::Registry(
+                registry.clone(),
                 "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a".to_owned(),
             ),
         },
@@ -153,7 +163,9 @@ async fn some_missing() {
                     .expect("can't read");
 
             match krate.source {
-                Source::CratesIo(ref chksum) => cf::util::validate_checksum(&bytes, chksum)
+                // Source::CratesIo(ref chksum) => cf::util::validate_checksum(&bytes, chksum)
+                //     .expect("failed to validate checksum"),
+                Source::Registry(_, ref chksum) => cf::util::validate_checksum(&bytes, chksum)
                     .expect("failed to validate checksum"),
                 _ => unreachable!(),
             }
@@ -191,7 +203,9 @@ async fn some_missing() {
                     .expect("can't read");
 
             match krate.source {
-                Source::CratesIo(ref chksum) => cf::util::validate_checksum(&bytes, chksum)
+                // Source::CratesIo(ref chksum) => cf::util::validate_checksum(&bytes, chksum)
+                //     .expect("failed to validate checksum"),
+                Source::Registry(_, ref chksum) => cf::util::validate_checksum(&bytes, chksum)
                     .expect("failed to validate checksum"),
                 _ => unreachable!(),
             }
@@ -212,12 +226,13 @@ async fn some_missing() {
 #[tokio::test(threaded_scheduler)]
 async fn none_missing() {
     let fs_root = tempfile::TempDir::new().expect("failed to create tempdir");
-    let registries = vec![Registry::new(
+    let registry = Registry::new(
         "https://github.com/rust-lang/crates.io-index".to_owned(),
         None,
+        Some("https://crates.io/api/v1/crates".to_owned()),
         None,
-        None,
-    )];
+    );
+    let registries = vec![registry.clone()];
     let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned(), registries).await;
 
     let missing_root = tempfile::TempDir::new().expect("failed to crate tempdir");
@@ -227,21 +242,24 @@ async fn none_missing() {
         Krate {
             name: "ansi_term".to_owned(),
             version: "0.11.0".to_owned(),
-            source: Source::CratesIo(
+            source: Source::Registry(
+                registry.clone(),
                 "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b".to_owned(),
             ),
         },
         Krate {
             name: "base64".to_owned(),
             version: "0.10.1".to_owned(),
-            source: Source::CratesIo(
+            source: Source::Registry(
+                registry.clone(),
                 "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e".to_owned(),
             ),
         },
         Krate {
             name: "uuid".to_owned(),
             version: "0.7.4".to_owned(),
-            source: Source::CratesIo(
+            source: Source::Registry(
+                registry.clone(),
                 "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a".to_owned(),
             ),
         },
@@ -271,7 +289,9 @@ async fn none_missing() {
                     .expect("can't read");
 
             match krate.source {
-                Source::CratesIo(ref chksum) => cf::util::validate_checksum(&bytes, chksum)
+                // Source::CratesIo(ref chksum) => cf::util::validate_checksum(&bytes, chksum)
+                //     .expect("failed to validate checksum"),
+                Source::Registry(_, ref chksum) => cf::util::validate_checksum(&bytes, chksum)
                     .expect("failed to validate checksum"),
                 _ => unreachable!(),
             }
@@ -308,7 +328,9 @@ async fn none_missing() {
                     .expect("can't read");
 
             match krate.source {
-                Source::CratesIo(ref chksum) => cf::util::validate_checksum(&bytes, chksum)
+                // Source::CratesIo(ref chksum) => cf::util::validate_checksum(&bytes, chksum)
+                //     .expect("failed to validate checksum"),
+                Source::Registry(_, ref chksum) => cf::util::validate_checksum(&bytes, chksum)
                     .expect("failed to validate checksum"),
                 _ => unreachable!(),
             }

--- a/tests/sync_git.rs
+++ b/tests/sync_git.rs
@@ -17,7 +17,7 @@ macro_rules! git_source {
 #[tokio::test(threaded_scheduler)]
 async fn multiple_from_same_repo() {
     let fs_root = tempfile::TempDir::new().expect("failed to create tempdir");
-    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned()).await;
+    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned(), Vec::new()).await;
 
     let missing_root = tempfile::TempDir::new().expect("failed to create tempdir");
     fs_ctx.root_dir = missing_root.path().to_owned();

--- a/tests/sync_git.rs
+++ b/tests/sync_git.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use cargo_fetcher as cf;
-use cf::{Krate, Source};
+use cf::{Krate, Registry, Source};
 
 mod tutil;
 use tutil as util;
@@ -17,7 +17,14 @@ macro_rules! git_source {
 #[tokio::test(threaded_scheduler)]
 async fn multiple_from_same_repo() {
     let fs_root = tempfile::TempDir::new().expect("failed to create tempdir");
-    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned(), Vec::new()).await;
+    let registry = Registry::new(
+        "https://github.com/rust-lang/crates.io-index".to_owned(),
+        None,
+        Some("https://crates.io/api/v1/crates".to_owned()),
+        None,
+    );
+    let registries = vec![registry.clone()];
+    let mut fs_ctx = util::fs_ctx(fs_root.path().to_owned(), registries).await;
 
     let missing_root = tempfile::TempDir::new().expect("failed to create tempdir");
     fs_ctx.root_dir = missing_root.path().to_owned();

--- a/tests/tutil.rs
+++ b/tests/tutil.rs
@@ -2,11 +2,11 @@ use cargo_fetcher as cf;
 
 use std::{path::PathBuf, sync::Arc};
 
-pub async fn fs_ctx(root: PathBuf) -> cf::Ctx {
+pub async fn fs_ctx(root: PathBuf, registries: Vec<cf::Registry>) -> cf::Ctx {
     let backend = Arc::new(
         cf::backends::fs::FSBackend::new(cf::FilesystemLocation { path: &root })
             .await
             .expect("failed to create fs backend"),
     );
-    cf::Ctx::new(None, backend, Vec::new(), Vec::new()).expect("failed to create context")
+    cf::Ctx::new(None, backend, Vec::new(), registries).expect("failed to create context")
 }

--- a/tests/tutil.rs
+++ b/tests/tutil.rs
@@ -8,5 +8,5 @@ pub async fn fs_ctx(root: PathBuf) -> cf::Ctx {
             .await
             .expect("failed to create fs backend"),
     );
-    cf::Ctx::new(None, backend, Vec::new()).expect("failed to create context")
+    cf::Ctx::new(None, backend, Vec::new(), Vec::new()).expect("failed to create context")
 }


### PR DESCRIPTION
1. Add a struct `Registry` to store the information of a registry, includes `dl` in it.
2. Find the registries need to be synced from `~/.cargo/config.toml` and `Cargo.lock`. The cargo config should include the `dl` of the registry, like this. 

```toml
[registries]
my-registry = { index = "https://my-intranet:8080/git/index", dl = "http://127.0.0.1/api/v1/crates" }
```
3. The registries that collected at the beginning will be used to mirror and sync itself. The registry stored in krate's source will be used to mirror and sync the crate.
4. Sync the registries and crates parallelly.