### PR TITLE
Add support for writing .cache entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --lib --tests --all-features -- -D warnings
+          args: --all-targets --all-features -- -D warnings
 
   test:
     name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+tests/full/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -410,10 +410,12 @@ dependencies = [
  "flate2",
  "futures",
  "futures-util",
+ "git2",
  "hex",
  "home",
  "http",
  "md5",
+ "memchr",
  "rayon",
  "remove_dir_all 0.6.1",
  "reqwest",
@@ -923,6 +925,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6503fe142514ca4799d4c26297c4248239fe8838d827db6bd6065c6ed29a6ce"
 
 [[package]]
+name = "git2"
+version = "0.13.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca6f1a0238d7f8f8fd5ee642f4ebac4dbc03e03d1f78fbe7a3ede35dcf7e2224"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "openssl-probe",
+ "openssl-sys",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1228,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.12.14+1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f25af58e6495f7caf2919d08f212de550cfa3ed2f5e744988938ea292b9f549"
+dependencies = [
+ "cc",
+ "libc",
+ "libssh2-sys",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df40b13fe7ea1be9b9dffa365a51273816c345fc1811478b57ed7d964fbfc4ce"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "602113192b08db8f38796c4e85c39e960c145965140e918018bcde1952429655"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1499,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.12.0+1.1.1h"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "858a4132194f8570a7ee9eb8629e85b23cbc4565f2d4a162e87556e5956abf61"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "openssl-src",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "parking"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1615,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
 name = "polling"
@@ -2735,6 +2821,12 @@ checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
 dependencies = [
  "rand",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
 name = "vec-arena"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ futures-util = { version = "0.3", features = ["async-await-macro"] }
 hex = { version = "0.4", optional = true }
 home = "0.5"
 http = "0.2"
+memchr = "2.3"
 md5 = { version = "0.7", optional = true }
 rayon = "1.5"
 remove_dir_all = "0.6"
@@ -54,6 +55,12 @@ tracing-subscriber = "0.2"
 url = { version = "2.2", features = ["serde"] }
 walkdir = "2.3"
 zstd = "0.5"
+
+[dependencies.git2]
+version = "0.13"
+# We enable this feature so that we can easily compile for eg. musl, and dodge
+# a bunch of shenanigans with openssl differences on different distros
+features = ["vendored-openssl"]
 
 [dependencies.tokio]
 version = "0.2"

--- a/deny.toml
+++ b/deny.toml
@@ -23,13 +23,6 @@ ignore = [
 [bans]
 multiple-versions = "deny"
 deny = [
-    # we never want a dependency on openssl due to all of the cross platform
-    # issues it has, particularly on windows
-    { name = "openssl" },
-    { name = "openssl-sys" },
-
-    # dirs is ridiculously heavyweight for what it does...sigh rusoto
-    #{ name = "dirs-sys" },
 ]
 skip = [
     # clap still uses an old ansi_term

--- a/src/cmds/mirror.rs
+++ b/src/cmds/mirror.rs
@@ -28,21 +28,23 @@ pub(crate) async fn cmd(ctx: Ctx, include_index: bool, args: Args) -> Result<(),
     let backend = ctx.backend.clone();
 
     let local = tokio::task::LocalSet::new();
-    let regs = ctx.registries.to_vec();
+
+    let regs = ctx.registry_sets();
+
     let index = local.run_until(async move {
         if !include_index {
             return;
         }
 
         if let Err(e) = tokio::task::spawn_local(async move {
-            match mirror::registries_index(backend, args.max_stale, regs)
+            match mirror::registry_indices(backend, args.max_stale, regs)
                 .instrument(tracing::info_span!("index"))
                 .await
             {
                 Ok(_) => {
-                    info!("successfully mirrored all registries index");
+                    info!("successfully mirrored all registry indices");
                 }
-                Err(e) => error!("failed to mirror registries index: {:#}", e),
+                Err(e) => error!("failed to mirror all registry indices: {:#}", e),
             }
         })
         .await

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -1,10 +1,12 @@
+mod git;
+
 use crate::{cargo::Source, util, Krate};
 use anyhow::{bail, Context, Error};
 use bytes::Bytes;
 use reqwest::Client;
 use std::path::Path;
 use tokio::process::Command;
-use tracing::{debug, error};
+use tracing::{error, warn};
 use tracing_futures::Instrument;
 
 pub async fn from_registry(client: &Client, krate: &Krate) -> Result<Bytes, Error> {
@@ -14,7 +16,6 @@ pub async fn from_registry(client: &Client, krate: &Krate) -> Result<Bytes, Erro
             Source::Registry { registry, chksum } => {
                 let url = registry.download_url(krate);
 
-                // TODO use token in private registry
                 let response = client.get(&url).send().await?.error_for_status()?;
                 let res = util::convert_response(response).await?;
                 let content = res.into_body();
@@ -154,36 +155,59 @@ pub async fn update_bare(krate: &Krate, path: &Path) -> Result<(), Error> {
     Ok(())
 }
 
-pub async fn registry(url: &url::Url) -> Result<Bytes, Error> {
+pub async fn registry(
+    url: &url::Url,
+    krates: impl Iterator<Item = String> + Send + 'static,
+) -> Result<Bytes, Error> {
+    // We don't bother to suport older versions of cargo that don't support
+    // bare checkouts of registry indexes, as that has been in since early 2017
     // See https://github.com/rust-lang/cargo/blob/0e38712d4d7b346747bf91fb26cce8df6934e178/src/cargo/sources/registry/remote.rs#L61
-    // for why we go through the whole repo init process + fetch instead of just a bare clone
+    // for details on why cargo still does what it does
     let temp_dir = tempfile::tempdir()?;
 
-    let output = Command::new("git")
-        .arg("init")
-        .arg("--template=''") // Ensure we don't get any templates
-        .current_dir(&temp_dir)
-        .output()
-        .await
-        .context("git-init")?;
+    let mut init_opts = git2::RepositoryInitOptions::new();
+    //init_opts.bare(true);
+    init_opts.external_template(false);
 
-    if !output.status.success() {
-        bail!("failed to initialize registry index repo");
-    }
+    let repo =
+        git2::Repository::init_opts(&temp_dir, &init_opts).context("failed to initialize repo")?;
 
-    debug!("fetching crates.io index");
-    let output = Command::new("git")
-        .arg("fetch")
-        .arg(url.as_str())
-        .arg("refs/heads/master:refs/remotes/origin/master")
-        .current_dir(temp_dir.path())
-        .output()
-        .await
-        .context("git-fetch")?;
+    let url = url.as_str().to_owned();
 
-    if !output.status.success() {
-        bail!("failed to fetch registry index");
-    }
+    // We need to ship off the fetching to a blocking thread so we don't anger tokio
+    tokio::task::spawn_blocking(move || -> Result<(), Error> {
+        let git_config =
+            git2::Config::open_default().context("Failed to open default git config")?;
+
+        git::with_fetch_options(&git_config, &url, &mut |mut opts| {
+            repo.remote_anonymous(&url)?
+                .fetch(
+                    &[
+                        "refs/heads/master:refs/remotes/origin/master",
+                        "HEAD:refs/remotes/origin/HEAD",
+                    ],
+                    Some(&mut opts),
+                    None,
+                )
+                .context("Failed to fetch")
+        })?;
+
+        let write_cache = tracing::span!(
+            tracing::Level::DEBUG,
+            "write-cache-entries",
+            registry = url.as_str()
+        );
+
+        write_cache.in_scope(|| {
+            if let Err(e) = write_cache_entries(repo, krates) {
+                error!("Failed to write all .cache entries: {:#}", e);
+            }
+        });
+
+        Ok(())
+    })
+    .instrument(tracing::debug_span!("fetch"))
+    .await??;
 
     // We also write a `.last-updated` file just like cargo so that cargo knows
     // the timestamp of the fetch
@@ -193,4 +217,151 @@ pub async fn registry(url: &url::Url) -> Result<Bytes, Error> {
     util::pack_tar(temp_dir.path())
         .instrument(tracing::debug_span!("tarball"))
         .await
+}
+
+/// Writes .cache entries in the registry's directory for all of the specified
+/// crates. Cargo will write these entries itself if they don't exist the first
+/// time it tries to access the crate's metadata, but this noticeably increases
+/// initial fetch times. (see src/cargo/sources/registry/index.rs)
+fn write_cache_entries(
+    repo: git2::Repository,
+    krates: impl Iterator<Item = String>,
+) -> Result<(), Error> {
+    // the path to the repository itself for bare repositories.
+    let cache = if repo.is_bare() {
+        repo.path().join(".cache")
+    } else {
+        repo.path().parent().unwrap().join(".cache")
+    };
+
+    std::fs::create_dir_all(&cache)?;
+
+    // Every .cache entry encodes the sha1 it was created at in the beginning
+    // so that cargo knows when an entry is out of date with the current HEAD
+    let head_commit = {
+        let branch = repo
+            .find_branch("origin/master", git2::BranchType::Remote)
+            .context("failed to find 'master' branch")?;
+        branch
+            .get()
+            .target()
+            .context("unable to find commit for 'master' branch")?
+    };
+    let head_commit_str = head_commit.to_string();
+
+    let tree = repo
+        .find_commit(head_commit)
+        .context("failed to find HEAD commit")?
+        .tree()
+        .context("failed to get commit tree")?;
+
+    // These can get rather large, so be generous
+    let mut buffer = Vec::with_capacity(32 * 1024);
+
+    for krate in krates {
+        // cargo always normalizes paths to lowercase
+        let lkrate = krate.to_lowercase();
+        let mut rel_path = crate::cargo::get_crate_prefix(&lkrate);
+        rel_path.push('/');
+        rel_path.push_str(&lkrate);
+
+        let path = &Path::new(&rel_path);
+
+        buffer.clear();
+        if let Err(e) = write_summary(path, &repo, &tree, head_commit_str.as_bytes(), &mut buffer) {
+            warn!(
+                "unable to create cache entry for crate '{}': {:#}",
+                krate, e
+            );
+            continue;
+        }
+
+        let cache_path = cache.join(rel_path);
+
+        if let Err(e) = std::fs::create_dir_all(cache_path.parent().unwrap()) {
+            warn!(
+                "failed to create parent .cache directories for crate '{}': {:#}",
+                krate, e
+            );
+            continue;
+        }
+
+        if let Err(e) = std::fs::write(&cache_path, &buffer) {
+            warn!(
+                "failed to write .cache entry for crate '{}': {:#}",
+                krate, e
+            );
+        }
+    }
+
+    Ok(())
+}
+
+fn write_summary<'blob>(
+    path: &Path,
+    repo: &'blob git2::Repository,
+    tree: &git2::Tree<'blob>,
+    version: &[u8],
+    buffer: &mut Vec<u8>,
+) -> Result<(), Error> {
+    fn split<'a>(haystack: &'a [u8]) -> impl Iterator<Item = &'a [u8]> + 'a {
+        struct Split<'a> {
+            haystack: &'a [u8],
+        }
+
+        impl<'a> Iterator for Split<'a> {
+            type Item = &'a [u8];
+
+            fn next(&mut self) -> Option<&'a [u8]> {
+                if self.haystack.is_empty() {
+                    return None;
+                }
+                let (ret, remaining) = match memchr::memchr(b'\n', self.haystack) {
+                    Some(pos) => (&self.haystack[..pos], &self.haystack[pos + 1..]),
+                    None => (self.haystack, &[][..]),
+                };
+                self.haystack = remaining;
+                Some(ret)
+            }
+        }
+
+        Split { haystack }
+    }
+
+    let entry = tree
+        .get_path(path)
+        .context("failed to get entry for path")?;
+    let object = entry
+        .to_object(repo)
+        .context("failed to get object for entry")?;
+    let blob = object.as_blob().context("object is not a blob")?;
+
+    // Writes the binary summary for the crate to a buffer, see
+    // src/cargo/sources/registry/index.rs for details
+    const CURRENT_CACHE_VERSION: u8 = 1;
+
+    buffer.push(CURRENT_CACHE_VERSION);
+    buffer.extend_from_slice(version);
+    buffer.push(0);
+
+    for (version, data) in split(blob.content()).filter_map(|line| {
+        std::str::from_utf8(line).ok().and_then(|lstr| {
+            // We need to get the version, as each entry in the .cache
+            // entry is a tuple of the version and the summary
+            lstr.find("\"vers\":\"")
+                .and_then(|ind| {
+                    lstr[ind + 8..]
+                        .find('"')
+                        .map(|nind| ind + 8..nind + ind + 8)
+                })
+                .map(|version_range| (&line[version_range], line))
+        })
+    }) {
+        buffer.extend_from_slice(version);
+        buffer.push(0);
+        buffer.extend_from_slice(data);
+        buffer.push(0);
+    }
+
+    Ok(())
 }

--- a/src/fetch/git.rs
+++ b/src/fetch/git.rs
@@ -1,0 +1,285 @@
+use anyhow::Error;
+
+pub(crate) fn with_fetch_options(
+    git_config: &git2::Config,
+    url: &str,
+    cb: &mut dyn FnMut(git2::FetchOptions<'_>) -> Result<(), Error>,
+) -> Result<(), Error> {
+    with_authentication(url, git_config, |f| {
+        let mut rcb = git2::RemoteCallbacks::new();
+        rcb.credentials(f);
+
+        // rcb.transfer_progress(|stats| {
+        //     progress
+        //         .tick(stats.indexed_objects(), stats.total_objects())
+        //         .is_ok()
+        // });
+
+        // Create a local anonymous remote in the repository to fetch the
+        // url
+        let mut opts = git2::FetchOptions::new();
+        opts.remote_callbacks(rcb);
+        cb(opts)
+    })?;
+    Ok(())
+}
+
+/// Prepare the authentication callbacks for cloning a git repository.
+///
+/// The main purpose of this function is to construct the "authentication
+/// callback" which is used to clone a repository. This callback will attempt to
+/// find the right authentication on the system (without user input) and will
+/// guide libgit2 in doing so.
+///
+/// The callback is provided `allowed` types of credentials, and we try to do as
+/// much as possible based on that:
+///
+/// * Prioritize SSH keys from the local ssh agent as they're likely the most
+///   reliable. The username here is prioritized from the credential
+///   callback, then from whatever is configured in git itself, and finally
+///   we fall back to the generic user of `git`.
+///
+/// * If a username/password is allowed, then we fallback to git2-rs's
+///   implementation of the credential helper. This is what is configured
+///   with `credential.helper` in git, and is the interface for the macOS
+///   keychain, for example.
+///
+/// * After the above two have failed, we just kinda grapple attempting to
+///   return *something*.
+///
+/// If any form of authentication fails, libgit2 will repeatedly ask us for
+/// credentials until we give it a reason to not do so. To ensure we don't
+/// just sit here looping forever we keep track of authentications we've
+/// attempted and we don't try the same ones again.
+fn with_authentication<T, F>(url: &str, cfg: &git2::Config, mut f: F) -> Result<T, Error>
+where
+    F: FnMut(&mut git2::Credentials<'_>) -> Result<T, Error>,
+{
+    use std::env;
+
+    let mut cred_helper = git2::CredentialHelper::new(url);
+    cred_helper.config(cfg);
+
+    let mut ssh_username_requested = false;
+    let mut cred_helper_bad = None;
+    let mut ssh_agent_attempts = Vec::new();
+    let mut any_attempts = false;
+    let mut tried_sshkey = false;
+    let mut url_attempt = None;
+
+    let orig_url = url;
+    let mut res = f(&mut |url, username, allowed| {
+        any_attempts = true;
+        if url != orig_url {
+            url_attempt = Some(url.to_string());
+        }
+        // libgit2's "USERNAME" authentication actually means that it's just
+        // asking us for a username to keep going. This is currently only really
+        // used for SSH authentication and isn't really an authentication type.
+        // The logic currently looks like:
+        //
+        //      let user = ...;
+        //      if (user.is_null())
+        //          user = callback(USERNAME, null, ...);
+        //
+        //      callback(SSH_KEY, user, ...)
+        //
+        // So if we're being called here then we know that (a) we're using ssh
+        // authentication and (b) no username was specified in the URL that
+        // we're trying to clone. We need to guess an appropriate username here,
+        // but that may involve a few attempts. Unfortunately we can't switch
+        // usernames during one authentication session with libgit2, so to
+        // handle this we bail out of this authentication session after setting
+        // the flag `ssh_username_requested`, and then we handle this below.
+        if allowed.contains(git2::CredentialType::USERNAME) {
+            debug_assert!(username.is_none());
+            ssh_username_requested = true;
+            return Err(git2::Error::from_str("gonna try usernames later"));
+        }
+
+        // An "SSH_KEY" authentication indicates that we need some sort of SSH
+        // authentication. This can currently either come from the ssh-agent
+        // process or from a raw in-memory SSH key. Cargo only supports using
+        // ssh-agent currently.
+        //
+        // If we get called with this then the only way that should be possible
+        // is if a username is specified in the URL itself (e.g., `username` is
+        // Some), hence the unwrap() here. We try custom usernames down below.
+        if allowed.contains(git2::CredentialType::SSH_KEY) && !tried_sshkey {
+            // If ssh-agent authentication fails, libgit2 will keep
+            // calling this callback asking for other authentication
+            // methods to try. Make sure we only try ssh-agent once,
+            // to avoid looping forever.
+            tried_sshkey = true;
+            let username = username.unwrap();
+            debug_assert!(!ssh_username_requested);
+            ssh_agent_attempts.push(username.to_string());
+            return git2::Cred::ssh_key_from_agent(username);
+        }
+
+        // Sometimes libgit2 will ask for a username/password in plaintext. This
+        // is where Cargo would have an interactive prompt if we supported it,
+        // but we currently don't! Right now the only way we support fetching a
+        // plaintext password is through the `credential.helper` support, so
+        // fetch that here.
+        //
+        // If ssh-agent authentication fails, libgit2 will keep calling this
+        // callback asking for other authentication methods to try. Check
+        // cred_helper_bad to make sure we only try the git credentail helper
+        // once, to avoid looping forever.
+        if allowed.contains(git2::CredentialType::USER_PASS_PLAINTEXT) && cred_helper_bad.is_none()
+        {
+            let r = git2::Cred::credential_helper(cfg, url, username);
+            cred_helper_bad = Some(r.is_err());
+            return r;
+        }
+
+        // I'm... not sure what the DEFAULT kind of authentication is, but seems
+        // easy to support?
+        if allowed.contains(git2::CredentialType::DEFAULT) {
+            return git2::Cred::default();
+        }
+
+        // Whelp, we tried our best
+        Err(git2::Error::from_str("no authentication available"))
+    });
+
+    // Ok, so if it looks like we're going to be doing ssh authentication, we
+    // want to try a few different usernames as one wasn't specified in the URL
+    // for us to use. In order, we'll try:
+    //
+    // * A credential helper's username for this URL, if available.
+    // * This account's username.
+    // * "git"
+    //
+    // We have to restart the authentication session each time (due to
+    // constraints in libssh2 I guess? maybe this is inherent to ssh?), so we
+    // call our callback, `f`, in a loop here.
+    if ssh_username_requested {
+        debug_assert!(res.is_err());
+        let mut attempts = Vec::new();
+        attempts.push("git".to_string());
+        if let Ok(s) = env::var("USER").or_else(|_| env::var("USERNAME")) {
+            attempts.push(s);
+        }
+        if let Some(ref s) = cred_helper.username {
+            attempts.push(s.clone());
+        }
+
+        while let Some(s) = attempts.pop() {
+            // We should get `USERNAME` first, where we just return our attempt,
+            // and then after that we should get `SSH_KEY`. If the first attempt
+            // fails we'll get called again, but we don't have another option so
+            // we bail out.
+            let mut attempts = 0;
+            res = f(&mut |_url, username, allowed| {
+                if allowed.contains(git2::CredentialType::USERNAME) {
+                    return git2::Cred::username(&s);
+                }
+                if allowed.contains(git2::CredentialType::SSH_KEY) {
+                    debug_assert_eq!(Some(&s[..]), username);
+                    attempts += 1;
+                    if attempts == 1 {
+                        ssh_agent_attempts.push(s.to_string());
+                        return git2::Cred::ssh_key_from_agent(&s);
+                    }
+                }
+                Err(git2::Error::from_str("no authentication available"))
+            });
+
+            // If we made two attempts then that means:
+            //
+            // 1. A username was requested, we returned `s`.
+            // 2. An ssh key was requested, we returned to look up `s` in the
+            //    ssh agent.
+            // 3. For whatever reason that lookup failed, so we were asked again
+            //    for another mode of authentication.
+            //
+            // Essentially, if `attempts == 2` then in theory the only error was
+            // that this username failed to authenticate (e.g., no other network
+            // errors happened). Otherwise something else is funny so we bail
+            // out.
+            if attempts != 2 {
+                break;
+            }
+        }
+    }
+    let mut err = match res {
+        Ok(e) => return Ok(e),
+        Err(e) => e,
+    };
+
+    // In the case of an authentication failure (where we tried something) then
+    // we try to give a more helpful error message about precisely what we
+    // tried.
+    if any_attempts {
+        let mut msg = "failed to authenticate when downloading \
+                       repository"
+            .to_string();
+
+        if let Some(attempt) = &url_attempt {
+            if url != attempt {
+                msg.push_str(": ");
+                msg.push_str(attempt);
+            }
+        }
+        msg.push('\n');
+        if !ssh_agent_attempts.is_empty() {
+            let names = ssh_agent_attempts
+                .iter()
+                .map(|s| format!("`{}`", s))
+                .collect::<Vec<_>>()
+                .join(", ");
+            msg.push_str(&format!(
+                "\n* attempted ssh-agent authentication, but \
+                 no usernames succeeded: {}",
+                names
+            ));
+        }
+        if let Some(failed_cred_helper) = cred_helper_bad {
+            if failed_cred_helper {
+                msg.push_str(
+                    "\n* attempted to find username/password via \
+                     git's `credential.helper` support, but failed",
+                );
+            } else {
+                msg.push_str(
+                    "\n* attempted to find username/password via \
+                     `credential.helper`, but maybe the found \
+                     credentials were incorrect",
+                );
+            }
+        }
+        msg.push_str("\n\n");
+        msg.push_str("if the git CLI succeeds then `net.git-fetch-with-cli` may help here\n");
+        msg.push_str("https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli");
+        err = err.context(msg);
+
+    // Otherwise if we didn't even get to the authentication phase them we may
+    // have failed to set up a connection, in these cases hint on the
+    // `net.git-fetch-with-cli` configuration option.
+    } else if let Some(e) = err.downcast_ref::<git2::Error>() {
+        use git2::ErrorClass;
+        match e.class() {
+            ErrorClass::Net
+            | ErrorClass::Ssl
+            | ErrorClass::Submodule
+            | ErrorClass::FetchHead
+            | ErrorClass::Ssh
+            | ErrorClass::Callback
+            | ErrorClass::Http => {
+                let mut msg = "network failure seems to have happened\n".to_string();
+                msg.push_str(
+                    "if a proxy or similar is necessary `net.git-fetch-with-cli` may help here\n",
+                );
+                msg.push_str(
+                    "https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli",
+                );
+                err = err.context(msg);
+            }
+            _ => {}
+        }
+    }
+
+    Err(err)
+}

--- a/tests/tutil.rs
+++ b/tests/tutil.rs
@@ -1,4 +1,5 @@
 #![cfg(feature = "fs")]
+#![allow(dead_code)]
 
 use cargo_fetcher as cf;
 use std::path::PathBuf;
@@ -13,7 +14,26 @@ pub async fn fs_ctx(root: PathBuf, registries: Vec<std::sync::Arc<cf::Registry>>
     cf::Ctx::new(None, backend, Vec::new(), registries).expect("failed to create context")
 }
 
-#[allow(dead_code)]
 pub fn get_sync_dirs(ctx: &cf::Ctx) -> (PathBuf, PathBuf) {
     ctx.registries[0].sync_dirs(&ctx.root_dir)
+}
+
+pub fn hook_logger() {
+    const HOOK: std::sync::Once = std::sync::Once::new();
+
+    HOOK.call_once(|| {
+        let mut env_filter = tracing_subscriber::EnvFilter::from_default_env();
+
+        // If a user specifies a log level, we assume it only pertains to cargo_fetcher,
+        // if they want to trace other crates they can use the RUST_LOG env approach
+        env_filter = env_filter.add_directive(
+            format!("cargo_fetcher={}", tracing::Level::DEBUG)
+                .parse()
+                .unwrap(),
+        );
+
+        let subscriber = tracing_subscriber::FmtSubscriber::builder().with_env_filter(env_filter);
+
+        tracing::subscriber::set_global_default(subscriber.finish()).unwrap();
+    });
 }

--- a/tests/tutil.rs
+++ b/tests/tutil.rs
@@ -19,7 +19,7 @@ pub fn get_sync_dirs(ctx: &cf::Ctx) -> (PathBuf, PathBuf) {
 }
 
 pub fn hook_logger() {
-    const HOOK: std::sync::Once = std::sync::Once::new();
+    static HOOK: std::sync::Once = std::sync::Once::new();
 
     HOOK.call_once(|| {
         let mut env_filter = tracing_subscriber::EnvFilter::from_default_env();


### PR DESCRIPTION
Adds support for .cache entries, which are created by cargo lazily when it needs to read a crate's metadata. Since cargo (usually) doesn't do a full checkout of a registry index, it will look up the .cache entry for a crate, which is just a slightly different binary representation of the normal index entries, but when it doesn't have that, it actually reads the index entry for the crate directly from git, serializes the cache entry so it doesn't need to to it again (until the index is updated), then returns the crate details. This was the cause of a cargo operation  taking multiple seconds even after a sync, where we thought we had faithfully replicated what cargo was doing (tested via the diff_cargo) test, but had not written the cache entries, which cargo would then do when it tried to access any of the crates being built/etc.

Resolves: #16
Resolves: #117 