### PR TITLE
fixex up s3 endpoint formating

### DIFF
--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -12,7 +12,7 @@ impl S3Backend {
     pub fn new(loc: crate::S3Location<'_>) -> Result<Self, Error> {
         let region = rusoto_core::Region::Custom {
             name: loc.region.to_owned(),
-            endpoint: loc.host.to_owned(),
+            endpoint: format!("https://s3.{}.{}", loc.region, loc.host),
         };
 
         let client = S3Client::new(region);


### PR DESCRIPTION
Use `loc.host` as `endpoint`, we will get an error like this. 

`Jan 16 23:41:47.400 ERROR cargo_fetcher::mirror: failed to mirror crates: failed to list objects: Error during dispatch: error trying to connect: tls handshake eof: Error during dispatch: error trying to connect: tls handshake eof`