### PR TITLE
Fixup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,9 +2047,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 dependencies = [
  "serde",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -54,6 +54,7 @@ unlicensed = "deny"
 confidence-threshold = 0.92
 allow = [
     "Apache-2.0",
+    "BSD-2-Clause",
     "BSD-3-Clause",
     "ISC",
     "MIT",

--- a/deny.toml
+++ b/deny.toml
@@ -16,6 +16,8 @@ ignore = [
     "RUSTSEC-2019-0036",
     # failure is unmaintained
     "RUSTSEC-2020-0036",
+    # difference is unmaintained, but it suits our needs just fine
+    "RUSTSEC-2020-0095",
 ]
 
 [bans]

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -22,7 +22,7 @@ impl S3Backend {
         let path_style = false;
         let bucket = Bucket::new(endpoint, path_style, loc.bucket.into(), loc.region.into())
             .context("failed to new Bucket")?;
-        let credential = Credentials::new(key.into(), secret.into());
+        let credential = Credentials::new(key, secret);
         let client = Client::new();
 
         Ok(Self {
@@ -103,7 +103,7 @@ impl crate::Backend for S3Backend {
         Ok(parsed
             .contents
             .into_iter()
-            .filter_map(|obj| Some(obj.key))
+            .map(|obj| obj.key)
             .collect())
     }
 

--- a/src/backends/s3.rs
+++ b/src/backends/s3.rs
@@ -100,11 +100,7 @@ impl crate::Backend for S3Backend {
         let text = resp.text().await?;
         let parsed =
             ListObjectsV2::parse_response(&text).context("failed parsing list response")?;
-        Ok(parsed
-            .contents
-            .into_iter()
-            .map(|obj| obj.key)
-            .collect())
+        Ok(parsed.contents.into_iter().map(|obj| obj.key).collect())
     }
 
     async fn updated(&self, krate: &Krate) -> Result<Option<chrono::DateTime<chrono::Utc>>, Error> {

--- a/src/fetch.rs
+++ b/src/fetch.rs
@@ -302,7 +302,7 @@ fn write_summary<'blob>(
 }
 
 fn iter_index_entries(blob: &[u8]) -> impl Iterator<Item = (&[u8], &[u8])> {
-    fn split_blob<'a>(haystack: &'a [u8]) -> impl Iterator<Item = &'a [u8]> + 'a {
+    fn split_blob(haystack: &[u8]) -> impl Iterator<Item = &[u8]> {
         struct Split<'a> {
             haystack: &'a [u8],
         }

--- a/tests/diff_cargo.rs
+++ b/tests/diff_cargo.rs
@@ -106,10 +106,7 @@ fn hash<P: AsRef<Path>>(file: P) -> u64 {
             let mut chunk = [0; 8 * 1024];
 
             loop {
-                let read = match f.read(&mut chunk) {
-                    Ok(r) => r,
-                    Err(_) => 0xdead_beef,
-                };
+                let read = f.read(&mut chunk).unwrap_or(0xdead_beef);
 
                 if read > 0 {
                     xh.write(&chunk[..read]);


### PR DESCRIPTION
* Fixes new clippy lint from 1.49.0
* Updates smallvec to fix security advisory
* Ignores `difference` unmaintained advisory