### PR TITLE
Improve sync times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
+### Fixed
+- [PR#185](https://github.com/EmbarkStudios/cargo-fetcher/pull/185) significantly improved the speed of the sync subcommand.
+
 ## [0.14.3] - 2023-08-15
 ### Fixed
 - [PR#184](https://github.com/EmbarkStudios/cargo-fetcher/pull/184) fixed submodule checkout even better this time. For real this time.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,8 +112,8 @@ impl<'a> fmt::Display for CloudId<'a> {
 
 #[allow(dead_code)]
 pub struct GcsLocation<'a> {
-    bucket: &'a str,
-    prefix: &'a str,
+    pub bucket: &'a str,
+    pub prefix: &'a str,
 }
 
 #[allow(dead_code)]

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -433,7 +433,7 @@ pub async fn crates(ctx: &crate::Ctx) -> anyhow::Result<Summary> {
         let summary = summary.clone();
         let root_dir = root_dir.clone();
 
-        let handle = std::thread::spawn(move || {
+        std::thread::spawn(move || {
             let db_dir = &git_db_dir;
             let co_dir = &git_co_dir;
             let root_dir = &root_dir;
@@ -482,9 +482,7 @@ pub async fn crates(ctx: &crate::Ctx) -> anyhow::Result<Summary> {
                     });
                 }
             });
-        });
-
-        handle
+        })
     };
 
     // As each remote I/O op completes, pass it off to the thread pool to do

--- a/tests/diff_cargo.rs
+++ b/tests/diff_cargo.rs
@@ -204,6 +204,15 @@ async fn diff_cargo() {
 /// Validates that a cargo sync following a fetcher sync should do nothing
 #[tokio::test]
 async fn nothing_to_do() {
+    if std::env::var("CARGO_FETCHER_CRATES_IO_PROTOCOL")
+        .ok()
+        .as_deref()
+        == Some("git")
+    {
+        // Git registry is too unstable for diffing as the index changes too often
+        return;
+    }
+
     util::hook_logger();
 
     let sync_dir = util::tempdir();

--- a/tests/diff_cargo.rs
+++ b/tests/diff_cargo.rs
@@ -200,3 +200,58 @@ async fn diff_cargo() {
         assert_diff(fetcher_root, cargo_home);
     }
 }
+
+/// Validates that a cargo sync following a fetcher sync should do nothing
+#[tokio::test]
+async fn nothing_to_do() {
+    util::hook_logger();
+
+    let sync_dir = util::tempdir();
+    let fs_root = util::tempdir();
+
+    {
+        let (the_krates, registries) = cf::cargo::read_lock_files(
+            vec!["tests/full/Cargo.lock".into()],
+            vec![util::crates_io_registry()],
+        )
+        .unwrap();
+
+        let mut fs_ctx = util::fs_ctx(fs_root.pb(), registries);
+        fs_ctx.krates = the_krates;
+        fs_ctx.root_dir = sync_dir.pb();
+
+        let registry_sets = fs_ctx.registry_sets();
+        let the_registry = fs_ctx.registries[0].clone();
+
+        cf::mirror::registry_indices(&fs_ctx, std::time::Duration::new(10, 0), registry_sets).await;
+        cf::mirror::crates(&fs_ctx)
+            .await
+            .expect("failed to mirror crates");
+
+        fs_ctx.prep_sync_dirs().expect("create base dirs");
+        cf::sync::crates(&fs_ctx).await.expect("synced crates");
+        cf::sync::registry_index(&fs_ctx.root_dir, fs_ctx.backend.clone(), the_registry)
+            .await
+            .expect("failed to sync index");
+    }
+
+    let output = std::process::Command::new("cargo")
+        .env("CARGO_HOME", sync_dir.path())
+        .args([
+            "fetch",
+            "--locked",
+            "--manifest-path",
+            "tests/full/Cargo.toml",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+
+    if !stdout.is_empty() || !stderr.is_empty() {
+        panic!("expected no output from cargo, got:\nstdout:\n{stdout}\nstderr:{stderr}\n");
+    }
+}

--- a/tests/full/Cargo.lock
+++ b/tests/full/Cargo.lock
@@ -109,6 +109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +319,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -333,6 +348,9 @@ version = "0.1.0"
 dependencies = [
  "cpal",
  "gilrs",
+ "lmdb-rkv",
+ "lmdb-rkv-sys",
+ "meshopt",
  "sentry-contrib-breakpad",
  "tame-oauth",
 ]
@@ -351,7 +369,7 @@ dependencies = [
 [[package]]
 name = "gilrs"
 version = "0.10.2"
-source = "git+https://gitlab.com/gilrs-project/gilrs.git?rev=1bbec17c9ecb6884f96370064b34544f132c93af#1bbec17c9ecb6884f96370064b34544f132c93af"
+source = "git+https://gitlab.com/gilrs-project/gilrs.git?rev=1bbec17#1bbec17c9ecb6884f96370064b34544f132c93af"
 dependencies = [
  "fnv",
  "gilrs-core",
@@ -363,7 +381,7 @@ dependencies = [
 [[package]]
 name = "gilrs-core"
 version = "0.5.6"
-source = "git+https://gitlab.com/gilrs-project/gilrs.git?rev=1bbec17c9ecb6884f96370064b34544f132c93af#1bbec17c9ecb6884f96370064b34544f132c93af"
+source = "git+https://gitlab.com/gilrs-project/gilrs.git?rev=1bbec17#1bbec17c9ecb6884f96370064b34544f132c93af"
 dependencies = [
  "core-foundation",
  "io-kit-sys",
@@ -559,6 +577,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "lmdb-rkv"
+version = "0.14.0"
+source = "git+https://github.com/EmbarkStudios/lmdb-rs?branch=check-local-lib#26680a981882cfd2ddcb2d931f19975eb7554f71"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "libc",
+ "lmdb-rkv-sys",
+]
+
+[[package]]
+name = "lmdb-rkv-sys"
+version = "0.11.0"
+source = "git+https://github.com/EmbarkStudios/lmdb-rs?branch=check-local-lib#26680a981882cfd2ddcb2d931f19975eb7554f71"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +653,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "meshopt"
+version = "0.1.9"
+source = "git+https://github.com/EmbarkStudios/meshopt-rs?rev=16a3046#16a30462f38d67ea2cef355fbb10ef6c6c4daa32"
+dependencies = [
+ "cc",
+ "float-cmp",
+ "thiserror",
 ]
 
 [[package]]
@@ -1149,18 +1198,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dedd246497092a89beedfe2c9f176d44c1b672ea6090edc20544ade01fbb7ea0"
+checksum = "d9207952ae1a003f42d3d5e892dac3c6ba42aa6ac0c79a6a91a2b5cb4253e75c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d7b1fadccbbc7e19ea64708629f9d8dccd007c260d66485f20a6d41bc1cf4b3"
+checksum = "f1728216d3244de4f14f14f8c15c79be1a7c67867d28d69b719690e2a19fb445"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/tests/full/Cargo.toml
+++ b/tests/full/Cargo.toml
@@ -2,7 +2,7 @@
 name = "full"
 version = "0.1.0"
 authors = ["Jake Shadle <jake.shadle@embark-studios.com>"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # regular basic crate
@@ -14,7 +14,11 @@ cpal = { version = "0.13.5" }
 sentry-contrib-breakpad = { git = "https://github.com/EmbarkStudios/sentry-contrib-rust", rev = "5e10bd5ad" }
 # this repo on gitlab requires us to use the .git extension otherwise it will
 # redirect, but we still need to calculate the same hash as cargo for the local directory
-gilrs = { git = "https://gitlab.com/gilrs-project/gilrs.git", rev = "1bbec17c9ecb6884f96370064b34544f132c93af" }
+gilrs = { git = "https://gitlab.com/gilrs-project/gilrs.git", rev = "1bbec17" }
+# submodule
+meshopt = { git = "https://github.com/EmbarkStudios/meshopt-rs", rev = "16a3046" }
+lmdb-rkv = { git = "https://github.com/EmbarkStudios/lmdb-rs", branch = "check-local-lib" }
+lmdb-rkv-sys = { git = "https://github.com/EmbarkStudios/lmdb-rs", branch = "check-local-lib" }
 
 [patch.crates-io]
 cpal = { git = "https://github.com/RustAudio/cpal", rev = "971c46346" }

--- a/tests/tutil.rs
+++ b/tests/tutil.rs
@@ -78,7 +78,7 @@ pub fn hook_logger() {
         // If a user specifies a log level, we assume it only pertains to cargo_fetcher,
         // if they want to trace other crates they can use the RUST_LOG env approach
         env_filter = env_filter.add_directive(
-            format!("cargo_fetcher={}", tracing::Level::INFO)
+            format!("cargo_fetcher={}", tracing::Level::TRACE)
                 .parse()
                 .unwrap(),
         );


### PR DESCRIPTION
This adds a sanity check test to ensure cargo doesn't need to do work after we use cargo-fetcher, and while doing this noticed the error that I introduced in #181 that caused sync times to be slower than the non-async version.